### PR TITLE
feat: Schedule Domain API 구현(#15)

### DIFF
--- a/src/main/java/com/ellu/looper/commons/CurrentUserArgumentResolver.java
+++ b/src/main/java/com/ellu/looper/commons/CurrentUserArgumentResolver.java
@@ -10,7 +10,6 @@ import org.springframework.web.context.request.NativeWebRequest;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.method.support.ModelAndViewContainer;
 
-@Slf4j
 @Component
 public class CurrentUserArgumentResolver implements HandlerMethodArgumentResolver {
 
@@ -30,7 +29,6 @@ public class CurrentUserArgumentResolver implements HandlerMethodArgumentResolve
     Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
 
     if (authentication instanceof JwtAuthenticationToken jwtAuthToken) {
-      log.info("CurrentUserArgumentResolver 호출됨");
 
       return jwtAuthToken.getPrincipal(); // userId
     }

--- a/src/main/java/com/ellu/looper/config/WebConfig.java
+++ b/src/main/java/com/ellu/looper/config/WebConfig.java
@@ -18,14 +18,3 @@ public class WebConfig implements WebMvcConfigurer {
     resolvers.add(currentUserArgumentResolver);
   }
 }
-
-// 아래처럼 사용 가능
-// @RestController
-// @RequestMapping("/api/users")
-// public class UserController {
-//
-//    @GetMapping("/me")
-//    public ResponseEntity<String> getCurrentUserId(@CurrentUser Long userId) {
-//        return ResponseEntity.ok("현재 로그인한 유저 ID: " + userId);
-//    }
-// }

--- a/src/main/java/com/ellu/looper/controller/ProjectController.java
+++ b/src/main/java/com/ellu/looper/controller/ProjectController.java
@@ -4,7 +4,6 @@ import com.ellu.looper.commons.ApiResponse;
 import com.ellu.looper.dto.ProjectCreateRequest;
 import com.ellu.looper.dto.ProjectResponse;
 import com.ellu.looper.dto.WikiRequest;
-import com.ellu.looper.entity.User;
 import com.ellu.looper.service.AiService;
 import com.ellu.looper.service.ProjectService;
 import com.ellu.looper.commons.CurrentUser;
@@ -23,47 +22,47 @@ public class ProjectController {
 
     @PostMapping
     public ResponseEntity<ApiResponse<?>> createProject(
-        @CurrentUser User loginUser,
+        @CurrentUser Long userId,
         @RequestBody ProjectCreateRequest request) {
-        projectService.createProject(request, loginUser.getId());
+        projectService.createProject(request, userId);
         return ResponseEntity.ok(ApiResponse.success("project_created", null));
     }
 
     @GetMapping
-    public ResponseEntity<ApiResponse<List<ProjectResponse>>> getProjects(@CurrentUser User loginUser) {
-        List<ProjectResponse> responses = projectService.getProjects(loginUser);
+    public ResponseEntity<ApiResponse<List<ProjectResponse>>> getProjects(@CurrentUser Long userId) {
+        List<ProjectResponse> responses = projectService.getProjects(userId);
         return ResponseEntity.ok(ApiResponse.success("project_list", responses));
     }
 
     @GetMapping("/{projectId}")
     public ResponseEntity<ApiResponse<ProjectResponse>> getProjectDetails(
-        @CurrentUser User loginUser,
+        @CurrentUser Long userId,
         @PathVariable Long projectId) {
-        ProjectResponse response = projectService.getProjectDetail(projectId, loginUser);
+        ProjectResponse response = projectService.getProjectDetail(projectId, userId);
         return ResponseEntity.ok(ApiResponse.success("project_fetched", response));
     }
 
     @PatchMapping("/{projectId}")
     public ResponseEntity<ApiResponse<ProjectResponse>> updateProject(
-        @CurrentUser User loginUser,
+        @CurrentUser Long userId,
         @PathVariable Long projectId,
         @RequestBody ProjectCreateRequest request) {
         ProjectResponse updated = null;
-            projectService.updateProject(projectId, request, loginUser);
+            projectService.updateProject(projectId, request, userId);
         return ResponseEntity.ok(ApiResponse.success("project_updated", updated));
     }
 
     @DeleteMapping("/{projectId}")
     public ResponseEntity<Void> deleteProject(
-        @CurrentUser User loginUser,
+        @CurrentUser Long userId,
         @PathVariable Long projectId) {
-        projectService.deleteProject(projectId, loginUser);
+        projectService.deleteProject(projectId, userId);
         return ResponseEntity.noContent().build();
     }
 
     @PostMapping("/{projectId}/wiki")
     public ResponseEntity<ApiResponse<?>> createWiki(
-        @CurrentUser User loginUser,
+        @CurrentUser Long userId,
         @PathVariable Long projectId,
         @RequestBody WikiRequest wikiRequest) {
         aiService.createProjectWiki(projectId, wikiRequest);
@@ -72,14 +71,14 @@ public class ProjectController {
 
     @GetMapping("/{projectId}/wiki")
     public ResponseEntity<ApiResponse<?>> getWiki(
-        @CurrentUser User loginUser,
+        @CurrentUser Long userId,
         @PathVariable Long projectId) {
         return ResponseEntity.ok(ApiResponse.success("wiki_fetched", aiService.getProjectWiki(projectId)));
     }
 
     @PatchMapping("/{projectId}/wiki")
     public ResponseEntity<ApiResponse<?>> updateWiki(
-        @CurrentUser User loginUser,
+        @CurrentUser Long userId,
         @PathVariable Long projectId,
         @RequestBody WikiRequest wikiRequest) {
         aiService.updateProjectWiki(projectId, wikiRequest);

--- a/src/main/java/com/ellu/looper/controller/ScheduleController.java
+++ b/src/main/java/com/ellu/looper/controller/ScheduleController.java
@@ -1,0 +1,114 @@
+package com.ellu.looper.controller;
+
+import com.ellu.looper.commons.CurrentUser;
+import com.ellu.looper.dto.schedule.ScheduleCreateRequest;
+import com.ellu.looper.dto.schedule.ScheduleResponse;
+import com.ellu.looper.dto.schedule.ScheduleUpdateRequest;
+import com.ellu.looper.service.ScheduleService;
+import jakarta.validation.Valid;
+import java.time.LocalDate;
+import java.time.YearMonth;
+import java.util.List;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/user/schedules")
+@RequiredArgsConstructor
+@Slf4j
+public class ScheduleController {
+
+  private final ScheduleService scheduleService;
+
+  @PostMapping
+  public ResponseEntity<?> create(@CurrentUser Long userId,
+      @Valid @RequestBody ScheduleCreateRequest request) {
+    ScheduleResponse response = scheduleService.createSchedule(userId, request);
+    return ResponseEntity.status(HttpStatus.CREATED).body(
+        Map.of("message", "schedule_created", "data", response));
+  }
+
+  @PatchMapping("/{id}")
+  public ResponseEntity<?> update(@CurrentUser Long userId,
+      @PathVariable Long id,
+      @Valid @RequestBody ScheduleUpdateRequest request) {
+    ScheduleResponse response = scheduleService.updateSchedule(userId, id, request);
+    return ResponseEntity.ok(Map.of("message", "schedule_updated", "data", response));
+  }
+
+  @DeleteMapping("/{id}")
+  public ResponseEntity<?> delete(@CurrentUser Long userId, @PathVariable Long id) {
+    scheduleService.deleteSchedule(userId, id);
+    return ResponseEntity.noContent().build();
+  }
+
+  @GetMapping("/daily")
+  public ResponseEntity<?> daily(@CurrentUser Long userId, @RequestParam String date) {
+    LocalDate localDate;
+    try {
+      localDate = LocalDate.parse(date);
+    } catch (Exception e) {
+      return ResponseEntity.badRequest().body(Map.of("message", "validation_failed", "data",
+          Map.of("errors",
+              Map.of("date", "Missing or invalid date parameter. Format must be YYYY-MM-DD."))));
+    }
+    List<ScheduleResponse> data = scheduleService.getDailySchedules(userId, localDate);
+    return ResponseEntity.ok(Map.of("message", "daily_schedule", "data", data));
+  }
+
+  @GetMapping("/weekly")
+  public ResponseEntity<?> weekly(@CurrentUser Long userId, @RequestParam String startDate) {
+    try {
+      LocalDate start = LocalDate.parse(startDate);
+      Map<LocalDate, List<ScheduleResponse>> data = scheduleService.getSchedulesByRange(userId,
+          start, start.plusDays(6));
+      return ResponseEntity.ok(Map.of("message", "weekly_schedule", "data", data));
+    } catch (Exception e) {
+      return ResponseEntity.badRequest().body(Map.of(
+          "message", "validation_failed",
+          "data", Map.of("errors",
+              Map.of("date", "Missing or invalid date parameter. Format must be YYYY-MM-DD."))));
+    }
+  }
+
+  @GetMapping("/monthly")
+  public ResponseEntity<?> monthly(@CurrentUser Long userId, @RequestParam String month) {
+    try {
+      YearMonth ym = YearMonth.parse(month);
+
+      Map<LocalDate, List<ScheduleResponse>> data = scheduleService.getSchedulesByRange(
+          userId, ym.atDay(1), ym.atEndOfMonth());
+      return ResponseEntity.ok(Map.of("message", "monthly_schedule", "data", data));
+    } catch (Exception e) {
+      return ResponseEntity.badRequest().body(Map.of("message", "validation_failed", "data",
+          Map.of("errors",
+              Map.of("date", "Missing or invalid month parameter. Format must be YYYY-MM."))));
+    }
+  }
+
+  @GetMapping("/yearly")
+  public ResponseEntity<?> yearly(@CurrentUser Long userId, @RequestParam String year) {
+    try {
+      int y = Integer.parseInt(year);
+      Map<LocalDate, List<ScheduleResponse>> data = scheduleService.getSchedulesByRange(
+          userId, LocalDate.of(y, 1, 1), LocalDate.of(y, 12, 31));
+      return ResponseEntity.ok(Map.of("message", "yearly_schedule", "data", data));
+    } catch (Exception e) {
+      return ResponseEntity.badRequest().body(Map.of("message", "validation_failed", "data",
+          Map.of("errors",
+              Map.of("date", "Missing or invalid year parameter. Format must be YYYY."))));
+    }
+  }
+}

--- a/src/main/java/com/ellu/looper/dto/schedule/ProjectScheduleCreateRequest.java
+++ b/src/main/java/com/ellu/looper/dto/schedule/ProjectScheduleCreateRequest.java
@@ -1,0 +1,31 @@
+package com.ellu.looper.dto.schedule;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import java.time.Instant;
+import java.util.List;
+
+public record ProjectScheduleCreateRequest(
+    @NotEmpty(message = "project_schedules must not be empty")
+    List<ProjectScheduleDto> project_schedules
+) {
+  public record ProjectScheduleDto(
+      @NotBlank(message = "title is required")
+      String title,
+
+      @NotNull(message = "start_time is required")
+      @JsonProperty("start_time")
+      Instant startTime,
+
+      @NotNull(message = "end_time is required")
+      @JsonProperty("end_time")
+      Instant endTime,
+
+      @NotNull(message = "is_completed is required")
+      @JsonProperty("is_completed")
+      Boolean isCompleted
+  ) {}
+}
+

--- a/src/main/java/com/ellu/looper/dto/schedule/ProjectScheduleCreateResponse.java
+++ b/src/main/java/com/ellu/looper/dto/schedule/ProjectScheduleCreateResponse.java
@@ -1,0 +1,29 @@
+package com.ellu.looper.dto.schedule;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.time.Instant;
+import java.util.List;
+
+public record ProjectScheduleCreateResponse(
+    String message,
+    Data data
+) {
+
+  public record Data(
+      List<ProjectScheduleDto> scheduled
+  ) {
+
+    public record ProjectScheduleDto(
+
+        String title,
+
+        @JsonProperty("start_time") Instant startTime,
+
+        @JsonProperty("end_time") Instant endTime,
+
+        @JsonProperty("is_completed") boolean completed
+    ) {
+
+    }
+  }
+}

--- a/src/main/java/com/ellu/looper/dto/schedule/ScheduleCreateRequest.java
+++ b/src/main/java/com/ellu/looper/dto/schedule/ScheduleCreateRequest.java
@@ -1,0 +1,23 @@
+package com.ellu.looper.dto.schedule;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import java.time.LocalDateTime;
+
+public record ScheduleCreateRequest(
+
+    @NotBlank String title,
+
+    String description,
+
+    @JsonProperty("isAiRecommended")
+    boolean aiRecommended,
+
+    @NotNull LocalDateTime startTime,
+
+    @NotNull LocalDateTime endTime
+
+) {
+
+}

--- a/src/main/java/com/ellu/looper/dto/schedule/ScheduleResponse.java
+++ b/src/main/java/com/ellu/looper/dto/schedule/ScheduleResponse.java
@@ -1,0 +1,34 @@
+package com.ellu.looper.dto.schedule;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.time.LocalDateTime;
+import lombok.Builder;
+
+@Builder
+public record ScheduleResponse(
+
+    String title,
+
+    String description,
+
+    @JsonProperty("isCompleted")
+    boolean completed,
+
+    @JsonProperty("isAiRecommended")
+    boolean aiRecommended,
+
+    @JsonProperty("isProjectSchedule")
+    boolean projectSchedule,
+
+    LocalDateTime startTime,
+
+    LocalDateTime endTime,
+
+    LocalDateTime createdAt,
+
+    LocalDateTime updatedAt
+
+) {
+
+}
+

--- a/src/main/java/com/ellu/looper/dto/schedule/ScheduleUpdateRequest.java
+++ b/src/main/java/com/ellu/looper/dto/schedule/ScheduleUpdateRequest.java
@@ -1,0 +1,21 @@
+package com.ellu.looper.dto.schedule;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.time.LocalDateTime;
+
+public record ScheduleUpdateRequest(
+
+    String title,
+
+    String description,
+
+    @JsonProperty("isCompleted")
+    Boolean completed,
+
+    LocalDateTime startTime,
+
+    LocalDateTime endTime
+) {
+
+}
+

--- a/src/main/java/com/ellu/looper/entity/Assignee.java
+++ b/src/main/java/com/ellu/looper/entity/Assignee.java
@@ -1,0 +1,61 @@
+package com.ellu.looper.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "assignee", indexes = {
+    @Index(name = "IDX_ASSIGNEE_MEMBER_ID", columnList = "member_id"),
+    @Index(name = "IDX_ASSIGNEE_PROJECT_SCHEDULE_ID", columnList = "project_schedule_id")
+})
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Assignee {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @ManyToOne(fetch = FetchType.LAZY, optional = false)
+  @JoinColumn(name = "project_schedule_id", nullable = false)
+  private ProjectSchedule projectSchedule;
+
+  @ManyToOne(fetch = FetchType.LAZY, optional = false)
+  @JoinColumn(name = "member_id", nullable = false)
+  private User user;
+
+  @Column(name = "created_at", nullable = false, updatable = false)
+  private LocalDateTime createdAt;
+
+  @Column(name = "deleted_at")
+  private LocalDateTime deletedAt;
+
+  @PrePersist
+  protected void onCreate() {
+    this.createdAt = LocalDateTime.now();
+  }
+
+  public void softDelete() {
+    this.deletedAt = LocalDateTime.now();
+  }
+
+  @Builder(toBuilder = true)
+  public Assignee(ProjectSchedule projectSchedule, User user) {
+    this.projectSchedule = projectSchedule;
+    this.user = user;
+  }
+}

--- a/src/main/java/com/ellu/looper/entity/ProjectSchedule.java
+++ b/src/main/java/com/ellu/looper/entity/ProjectSchedule.java
@@ -1,3 +1,113 @@
 package com.ellu.looper.entity;
 
-public class ProjectSchedule {}
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "project_schedule", indexes = {
+    @Index(name = "IDX_PROJECT_SCHEDULE_DELETED_AT", columnList = "deletedAt"),
+    @Index(name = "IDX_PROJECT_SCHEDULE_MEMBER_ID", columnList = "member_id"),
+    @Index(name = "IDX_PROJECT_SCHEDULE_IS_COMPLETED", columnList = "isCompleted")
+})
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ProjectSchedule {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @ManyToOne(fetch = FetchType.LAZY, optional = false)
+  @JoinColumn(name = "project_id", nullable = false)
+  private Project project;
+
+  @ManyToOne(fetch = FetchType.LAZY, optional = false)
+  @JoinColumn(name = "member_id", nullable = false)
+  private User user;
+
+  @Column(nullable = false, length = 255)
+  private String title;
+
+  @Column(columnDefinition = "TEXT")
+  private String description;
+
+  @Column(nullable = false, length = 15)
+  private String position;
+
+  @Column(name = "start_time", nullable = false)
+  private LocalDateTime startTime;
+
+  @Column(name = "end_time", nullable = false)
+  private LocalDateTime endTime;
+
+  @Column(name = "is_completed", nullable = false)
+  private boolean isCompleted = false;
+
+  @Column(name = "created_at", nullable = false, updatable = false)
+  private LocalDateTime createdAt;
+
+  @Column(name = "updated_at")
+  private LocalDateTime updatedAt;
+
+  @Column(name = "deleted_at")
+  private LocalDateTime deletedAt;
+
+  @OneToMany(mappedBy = "projectSchedule", cascade = CascadeType.ALL, orphanRemoval = true)
+  private List<Assignee> assignees = new ArrayList<>();
+
+  @PrePersist
+  protected void onCreate() {
+    this.createdAt = LocalDateTime.now();
+    this.updatedAt = this.createdAt;
+  }
+
+  @PreUpdate
+  protected void onUpdate() {
+    this.updatedAt = LocalDateTime.now();
+  }
+
+  public void softDelete() {
+    this.deletedAt = LocalDateTime.now();
+  }
+
+  @Builder(toBuilder = true)
+  public ProjectSchedule(Project project, User user, String title, String description, String position,
+      LocalDateTime startTime, LocalDateTime endTime, boolean isCompleted) {
+    this.project = project;
+    this.user = user;
+    this.title = title;
+    this.description = description;
+    this.position = position;
+    this.startTime = startTime;
+    this.endTime = endTime;
+    this.isCompleted = isCompleted;
+  }
+
+  public void update(String title, String description, LocalDateTime startTime,
+      LocalDateTime endTime, Boolean isCompleted) {
+    if (title != null) this.title = title;
+    if (description != null) this.description = description;
+    if (startTime != null) this.startTime = startTime;
+    if (endTime != null) this.endTime = endTime;
+    if (isCompleted != null) this.isCompleted = isCompleted;
+  }
+}

--- a/src/main/java/com/ellu/looper/entity/Schedule.java
+++ b/src/main/java/com/ellu/looper/entity/Schedule.java
@@ -1,3 +1,77 @@
 package com.ellu.looper.entity;
 
-public class Schedule {}
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+@Entity
+@Table(name = "schedule", indexes = {
+    @Index(name = "IDX_SCHEDULE_DELETED_AT", columnList = "deleted_at"),
+    @Index(name = "IDX_SCHEDULE_MEMBER_ID", columnList = "member_id"),
+    @Index(name = "IDX_SCHEDULE_IS_COMPLETED", columnList = "is_completed")
+})
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder(toBuilder = true)
+public class Schedule {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  @Column(nullable = false, updatable = false)
+  private Long id;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "member_id", nullable = false)
+  private User user;
+
+//  // Plan과의 연관관계 (nullable)
+//  @ManyToOne(fetch = FetchType.LAZY)
+//  @JoinColumn(name = "plan_id")
+//  private Plan plan;
+
+  @Column(nullable = false, length = 50)
+  private String title;
+
+  @Column
+  private String description;
+
+  @Column(name = "is_completed", nullable = false)
+  @Builder.Default
+  private boolean isCompleted = false;
+
+  @Column(name = "is_ai_recommended", nullable = false)
+  @Builder.Default
+  private boolean isAiRecommended = false;
+
+  @Column(name = "start_time", nullable = false)
+  private LocalDateTime startTime;
+
+  @Column(name = "end_time", nullable = false)
+  private LocalDateTime endTime;
+
+  @CreationTimestamp
+  @Column(name = "created_at", nullable = false, updatable = false)
+  private LocalDateTime createdAt;
+
+  @UpdateTimestamp
+  @Column(name = "updated_at", nullable = false)
+  private LocalDateTime updatedAt;
+
+  @Column(name = "deleted_at")
+  private LocalDateTime deletedAt;
+}

--- a/src/main/java/com/ellu/looper/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/ellu/looper/exception/GlobalExceptionHandler.java
@@ -21,6 +21,12 @@ public class GlobalExceptionHandler {
     return new ApiResponse<>("unauthorized or expired token", null);
   }
 
+  @ExceptionHandler(UserNotFoundException.class)
+  public ResponseEntity<ApiResponse<Void>> handleUserNotFound(UserNotFoundException ex) {
+    return ResponseEntity.status(HttpStatus.FORBIDDEN)
+        .body(new ApiResponse<>("user_not_found_or_unauthorized", null));
+  }
+
   @ExceptionHandler(RuntimeException.class)
   public ResponseEntity<?> handleRuntimeException(RuntimeException ex) {
     return ResponseEntity.status(HttpStatus.BAD_REQUEST)
@@ -45,10 +51,17 @@ public class GlobalExceptionHandler {
   }
 
   @ExceptionHandler(IllegalArgumentException.class)
-  public ApiResponse<Map<String, String>> handleIllegalArgument(IllegalArgumentException ex) {
+  public ResponseEntity<ApiResponse<Map<String, String>>> handleIllegalArgument(IllegalArgumentException ex) {
     Map<String, String> error = Map.of("message", ex.getMessage());
-    return new ApiResponse<>("validation_failed", error);
+    return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(new ApiResponse<>("validation_failed", error));
   }
+
+  @ExceptionHandler(NicknameAlreadyExistsException.class)
+  public ResponseEntity<?> handleNicknameAlreadyExists(NicknameAlreadyExistsException ex) {
+    return ResponseEntity.status(HttpStatus.CONFLICT) // 409
+        .body(new ApiResponse("닉네임이 이미 존재합니다.", null));
+  }
+
 
   @ExceptionHandler(Exception.class)
   public ResponseEntity<ErrorResponse> handleGenericException(Exception ex) {

--- a/src/main/java/com/ellu/looper/exception/NicknameAlreadyExistsException.java
+++ b/src/main/java/com/ellu/looper/exception/NicknameAlreadyExistsException.java
@@ -1,0 +1,8 @@
+package com.ellu.looper.exception;
+
+
+public class NicknameAlreadyExistsException extends RuntimeException {
+  public NicknameAlreadyExistsException(String message) {
+    super(message);
+  }
+}

--- a/src/main/java/com/ellu/looper/exception/UserNotFoundException.java
+++ b/src/main/java/com/ellu/looper/exception/UserNotFoundException.java
@@ -1,0 +1,10 @@
+package com.ellu.looper.exception;
+
+public class UserNotFoundException extends RuntimeException {
+  public UserNotFoundException(String message) {
+    super(message);
+  }
+}
+
+//User user = userRepository.findById(userId)
+//    .orElseThrow(() -> new UserNotFoundException("User not found or unauthorized"));

--- a/src/main/java/com/ellu/looper/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/ellu/looper/jwt/JwtAuthenticationFilter.java
@@ -20,7 +20,7 @@ import org.springframework.web.filter.OncePerRequestFilter;
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
   private final JwtProvider jwtProvider;
-  private final JwtService jwtService; // 토큰 저장소 (DB or Memory 등)
+  private final JwtService jwtService;
 
   public JwtAuthenticationFilter(JwtProvider jwtProvider, JwtService jwtService) {
     this.jwtProvider = jwtProvider;
@@ -49,8 +49,6 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
         SecurityContextHolder.getContext().setAuthentication(authentication);
         log.info("JwtAuthenticationFilter 실행됨. 인증된 유저 ID: {}", userId);
-        log.info("Authorization Header: {}", authHeader);
-        log.info("토큰에서 추출된 사용자 ID: {}", userId);
 
       } catch (JwtException e) {
         if ("Token expired".equals(e.getMessage())) {
@@ -109,7 +107,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     refreshCookie.setHttpOnly(true);
     refreshCookie.setSecure(true);
     refreshCookie.setPath("/");
-    refreshCookie.setMaxAge(60 * 60 * 24 * 14);
+    refreshCookie.setMaxAge((int) JwtExpiration.REFRESH_TOKEN_EXPIRATION);
 
     response.addCookie(refreshCookie);
   }

--- a/src/main/java/com/ellu/looper/repository/ProjectMemberRepository.java
+++ b/src/main/java/com/ellu/looper/repository/ProjectMemberRepository.java
@@ -7,11 +7,13 @@ import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
+import org.springframework.stereotype.Repository;
 
+@Repository
 public interface ProjectMemberRepository extends JpaRepository<ProjectMember, Long> {
 
     // 로그인한 사용자가 참여한 모든 프로젝트 멤버십 조회 (soft-delete 제외)
-    List<ProjectMember> findByUserAndDeletedAtIsNull(User member);
+    List<ProjectMember> findByUserIdAndDeletedAtIsNull(Long userId);
 
     // 특정 프로젝트의 멤버들 조회 (soft-delete 제외)
     List<ProjectMember> findByProjectAndDeletedAtIsNull(Project project);

--- a/src/main/java/com/ellu/looper/repository/ScheduleRepository.java
+++ b/src/main/java/com/ellu/looper/repository/ScheduleRepository.java
@@ -1,0 +1,30 @@
+package com.ellu.looper.repository;
+
+import com.ellu.looper.entity.Schedule;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
+
+  @Query("SELECT s FROM Schedule s WHERE s.user.id = :userId AND s.deletedAt IS NULL " +
+      "AND s.startTime < :end AND s.endTime >= :start")
+  List<Schedule> findDailySchedules(
+      @Param("userId") Long userId,
+      @Param("start") LocalDateTime start,
+      @Param("end") LocalDateTime end
+  );
+
+
+
+  @Query("SELECT s FROM Schedule s WHERE s.user.id = :userId AND s.deletedAt IS NULL AND s.startTime <=:end AND s.endTime>= :start")
+  List<Schedule> findSchedulesBetween(@Param("userId") Long userId, @Param("start") LocalDateTime start, @Param("end") LocalDateTime end);
+
+  Optional<Schedule> findByIdAndUserIdAndDeletedAtIsNull(Long id, Long userId);
+}

--- a/src/main/java/com/ellu/looper/service/ProjectScheduleService.java
+++ b/src/main/java/com/ellu/looper/service/ProjectScheduleService.java
@@ -1,0 +1,5 @@
+package com.ellu.looper.service;
+
+public class ProjectScheduleService {
+
+}

--- a/src/main/java/com/ellu/looper/service/ProjectService.java
+++ b/src/main/java/com/ellu/looper/service/ProjectService.java
@@ -99,9 +99,8 @@ public class ProjectService {
     }
 
     @Transactional(readOnly = true)
-    public List<ProjectResponse> getProjects(User loginUser) {
-        List<ProjectMember> memberships = projectMemberRepository.findByUserAndDeletedAtIsNull(
-            loginUser);
+    public List<ProjectResponse> getProjects(Long userId) {
+        List<ProjectMember> memberships = projectMemberRepository.findByUserIdAndDeletedAtIsNull(userId);
 
         return memberships.stream()
             .map(ProjectMember::getProject)
@@ -127,11 +126,11 @@ public class ProjectService {
     }
 
     @Transactional(readOnly = true)
-    public ProjectResponse getProjectDetail(Long projectId, User loginUser) {
+    public ProjectResponse getProjectDetail(Long projectId, Long userId) {
         Project project = projectRepository.findByIdAndDeletedAtIsNull(projectId)
             .orElseThrow(() -> new IllegalArgumentException("Project not found"));
 
-        if (!project.getMember().getId().equals(loginUser.getId())) {
+        if (!project.getMember().getId().equals(userId)) {
             throw new SecurityException("Only project creator can view this project");
         }
 
@@ -152,11 +151,11 @@ public class ProjectService {
     }
 
     @Transactional
-    public void deleteProject(Long projectId, User loginUser) {
+    public void deleteProject(Long projectId, Long userId) {
         Project project = projectRepository.findByIdAndDeletedAtIsNull(projectId)
             .orElseThrow(() -> new IllegalArgumentException("Project not found"));
 
-        if (!project.getMember().getId().equals(loginUser.getId())) {
+        if (!project.getMember().getId().equals(userId)) {
             throw new SecurityException("Only project creator can delete this project");
         }
 
@@ -173,11 +172,11 @@ public class ProjectService {
     }
 
     @Transactional
-    public void updateProject(Long projectId, ProjectCreateRequest request, User loginUser) {
+    public void updateProject(Long projectId, ProjectCreateRequest request, Long userId) {
         Project project = projectRepository.findByIdAndDeletedAtIsNull(projectId)
             .orElseThrow(() -> new IllegalArgumentException("Project not found"));
 
-        if (!project.getMember().getId().equals(loginUser.getId())) {
+        if (!project.getMember().getId().equals(userId)) {
             throw new SecurityException("Only project creator can update this project");
         }
 
@@ -206,7 +205,7 @@ public class ProjectService {
         // Update members
         List<ProjectMember> existing = projectMemberRepository.findByProjectAndDeletedAtIsNull(project);
         List<ProjectMember> toRemove = existing.stream()
-            .filter(pm -> !pm.getUser().getId().equals(loginUser.getId()) && updatedUsers.stream().noneMatch(u -> u.getId().equals(pm.getUser().getId())))
+            .filter(pm -> !pm.getUser().getId().equals(userId) && updatedUsers.stream().noneMatch(u -> u.getId().equals(pm.getUser().getId())))
             .collect(Collectors.toList());
 
         toRemove.forEach(pm -> pm.setDeletedAt(LocalDateTime.now()));

--- a/src/main/java/com/ellu/looper/service/ScheduleService.java
+++ b/src/main/java/com/ellu/looper/service/ScheduleService.java
@@ -1,0 +1,140 @@
+package com.ellu.looper.service;
+
+import com.ellu.looper.dto.schedule.ScheduleCreateRequest;
+import com.ellu.looper.dto.schedule.ScheduleResponse;
+import com.ellu.looper.dto.schedule.ScheduleUpdateRequest;
+import com.ellu.looper.entity.Schedule;
+import com.ellu.looper.entity.User;
+import com.ellu.looper.repository.ScheduleRepository;
+import com.ellu.looper.repository.UserRepository;
+import jakarta.validation.constraints.NotNull;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class ScheduleService {
+
+  private final ScheduleRepository scheduleRepository;
+  private final UserRepository memberRepository;
+
+  private void validateTimeOrder(LocalDateTime startTime, LocalDateTime endTime) {
+    if (endTime.isEqual(startTime) || endTime.isBefore(startTime)) {
+      throw new IllegalArgumentException("종료 시각은 시작 시각보다 나중이어야 합니다.");
+    }
+  }
+
+  public ScheduleResponse createSchedule(Long memberId, ScheduleCreateRequest request) {
+    User user = memberRepository.findById(memberId)
+        .orElseThrow(() -> new AccessDeniedException("unauthorized"));
+    
+    validateTimeOrder(request.startTime(), request.endTime());
+    
+    Schedule schedule = Schedule.builder()
+        .user(user)
+        .title(request.title())
+        .description(request.description())
+        .isAiRecommended(request.aiRecommended())
+        .isCompleted(false)
+        .startTime(request.startTime())
+        .endTime(request.endTime())
+        .build();
+    Schedule saved = scheduleRepository.save(schedule);
+    return toResponse(saved, false);
+  }
+
+
+  public ScheduleResponse updateSchedule(Long memberId, Long id, ScheduleUpdateRequest request) {
+    Schedule existing = scheduleRepository.findByIdAndUserIdAndDeletedAtIsNull(id, memberId)
+        .orElseThrow(() -> new IllegalArgumentException("Invalid or already deleted schedule"));
+
+    LocalDateTime newStart = request.startTime() != null ? request.startTime() : existing.getStartTime();
+    LocalDateTime newEnd = request.endTime() != null ? request.endTime() : existing.getEndTime();
+
+    validateTimeOrder(newStart, newEnd);
+
+    Schedule updated = existing.toBuilder()
+        .title(request.title() != null ? request.title() : existing.getTitle())
+        .description(
+            request.description() != null ? request.description() : existing.getDescription())
+        .isCompleted(request.completed() != null ? request.completed() : existing.isCompleted())
+        .startTime(request.startTime()!=null?request.startTime():existing.getStartTime())
+        .endTime(request.endTime() != null ? request.endTime() : existing.getEndTime())
+        .build();
+
+    return toResponse(scheduleRepository.save(updated), false);
+  }
+
+
+  public void deleteSchedule(Long memberId, Long id) {
+    Schedule schedule = scheduleRepository.findByIdAndUserIdAndDeletedAtIsNull(id, memberId)
+        .orElseThrow(() -> new IllegalArgumentException("Invalid or already deleted schedule"));
+    schedule.toBuilder().deletedAt(LocalDateTime.now()).build();
+    scheduleRepository.delete(schedule);
+  }
+
+  public List<ScheduleResponse> getDailySchedules(Long memberId, LocalDate date) {
+    LocalDateTime start = date.atStartOfDay();
+    LocalDateTime end = date.plusDays(1).atStartOfDay();
+
+    List<Schedule> personalSchedules = scheduleRepository.findDailySchedules(memberId, start, end);
+
+    List<ScheduleResponse> responses = personalSchedules.stream()
+        .map(s -> toResponse(s, false))
+        .collect(Collectors.toList());
+
+    List<ScheduleResponse> projectSchedules = getProjectSchedules(memberId, start, end);
+
+    responses.addAll(projectSchedules);
+    return responses;
+  }
+
+
+  public Map<LocalDate, List<ScheduleResponse>> getSchedulesByRange(Long memberId,
+      LocalDate startDate, LocalDate endDate) {
+    LocalDateTime start = startDate.atStartOfDay();
+    LocalDateTime end = endDate.plusDays(1).atStartOfDay().minusNanos(1); // 범위 끝을 포함시키기 위해
+
+    List<Schedule> personal = scheduleRepository.findSchedulesBetween(memberId, start, end);
+    List<ScheduleResponse> responses = personal.stream()
+        .map(s -> toResponse(s, false)).toList();
+
+    List<ScheduleResponse> project = getProjectSchedules(memberId, startDate.atStartOfDay(),
+        endDate.plusDays(1).atStartOfDay());
+
+    List<ScheduleResponse> all = new ArrayList<>();
+    all.addAll(responses);
+    all.addAll(project);
+
+    return all.stream().collect(Collectors.groupingBy(r -> r.startTime().toLocalDate()));
+  }
+
+  private List<ScheduleResponse> getProjectSchedules(Long memberId, LocalDateTime start,
+      LocalDateTime end) {
+    // ProjectScheduleService 에서 가져온다고 가정
+    return List.of(); // 예시
+  }
+
+  private ScheduleResponse toResponse(Schedule s, boolean isProject) {
+    return ScheduleResponse.builder()
+        .title(s.getTitle())
+        .description(s.getDescription())
+        .completed(s.isCompleted())
+        .aiRecommended(s.isAiRecommended())
+        .projectSchedule(isProject)
+        .startTime(s.getStartTime())
+        .endTime(s.getEndTime())
+        .createdAt(s.getCreatedAt())
+        .updatedAt(s.getUpdatedAt())
+        .build();
+  }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -12,5 +12,3 @@ spring.jpa.hibernate.ddl-auto=update
 
 # jwt configuration
 jwt.secret=204a843811dc12cdc884c9b3585790309200c25d220e0029567c1d90b66161f73f1577506ca7f357cd7fffb92b8ed4de8335ed8c4f02f693c9ac1f4dc422e1c2
-jwt.accessTokenExpiration= 1000L * 60 * 60;
-jwt.refreshTokenExpiration=1000L * 60 * 60 * 24 * 7;


### PR DESCRIPTION
## ☝️Issue Number
- resolve #

## 📍 PR 타입 (하나 이상 선택)
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정

## 📌 개요
- 개요 작성
Schedule domain의 API들을 구현함(참고: [Schedule 테크 스펙](https://www.notion.so/Schedule-1de177047bee80268ecee8a301fcf30e?pvs=10))  
POST /user/schedules : 개인 스케줄 생성  
PATCH /user/schedules/{id} : 개인 스케줄 수정  
DELETE /user/schedules/{id} : 개인 스케줄 삭제  
(GET /user/schedules/daily, GET /user/schedules/weekly, GET /user/schedules/monthly, GET /user/schedules/yearly): 유저가 속한 모든 스케줄 조회   


## ✅ 체크 리스트
- [x] 코드가 정상적으로 컴파일되는지 확인했습니다.
- [x] PR이 관련 이슈를 정확히 참조하고, 적절한 라벨을 선택했습니다.
- [ ] 모든 테스트가 성공적으로 통과했습니다.
- [x] 관련 문서를 WIKI에 업데이트했습니다.
- [ ] 코드 스타일 가이드라인을 준수했습니다.
- [ ] 코드 리뷰어를 지정했습니다.