### PR TITLE
Feat/#32 wiki api

### DIFF
--- a/src/main/java/com/ellu/looper/commons/PreviewHolder.java
+++ b/src/main/java/com/ellu/looper/commons/PreviewHolder.java
@@ -22,11 +22,20 @@ public class PreviewHolder {
 
   public void complete(Long projectId, Object aiResponse) {
     DeferredResult<ResponseEntity<?>> result = waitingClients.remove(projectId);
-    if (result != null) {
+    if (result != null && !result.isSetOrExpired()) {
       result.setResult(
           ResponseEntity.ok(Map.of("message", "schedule_fetched", "data", aiResponse)));
     }
   }
 
-  public void completeWithError(Long projectId, Throwable error) {}
+  public void completeWithError(Long projectId, Throwable error) {
+    DeferredResult<ResponseEntity<?>> result = waitingClients.remove(projectId);
+    if (result != null) {
+      result.setResult(
+          ResponseEntity.status(500).body(
+              Map.of("message", "internal_server_error", "data", null)
+          ));
+    }
+  }
+
 }

--- a/src/main/java/com/ellu/looper/controller/FastApiCallbackController.java
+++ b/src/main/java/com/ellu/looper/controller/FastApiCallbackController.java
@@ -1,0 +1,32 @@
+package com.ellu.looper.controller;
+
+import com.ellu.looper.dto.MeetingNoteResponse;
+import com.ellu.looper.service.FastApiService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/*
+* AI 서버로부터 콜백을 받는 컨트롤러
+*/
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/ai-callback")
+public class FastApiCallbackController {
+
+  private final FastApiService aiCallbackService;
+
+  @PostMapping("/projects/{projectId}/preview")
+  public ResponseEntity<?> receiveAiPreview(
+      @PathVariable Long projectId,
+      @RequestBody MeetingNoteResponse aiPreviewResponse) {
+
+    aiCallbackService.handleAiPreviewResponse(projectId, aiPreviewResponse);
+    return ResponseEntity.ok().build(); // AI에게 200 OK 응답
+  }
+}
+

--- a/src/main/java/com/ellu/looper/controller/ProjectController.java
+++ b/src/main/java/com/ellu/looper/controller/ProjectController.java
@@ -42,9 +42,8 @@ public class ProjectController {
       @CurrentUser Long userId,
       @PathVariable Long projectId,
       @RequestBody ProjectCreateRequest request) {
-    ProjectResponse updated = null;
     projectService.updateProject(projectId, request, userId);
-    return ResponseEntity.ok(ApiResponse.success("project_updated", updated));
+    return ResponseEntity.ok(ApiResponse.success("project_updated", null));
   }
 
   @DeleteMapping("/{projectId}")

--- a/src/main/java/com/ellu/looper/controller/WikiController.java
+++ b/src/main/java/com/ellu/looper/controller/WikiController.java
@@ -33,19 +33,6 @@ public class WikiController {
         .body(ApiResponse.success("wiki_uploaded", Map.of("status", "success")));
   }
 
-  @GetMapping("/wiki")
-  public ResponseEntity<ApiResponse<?>> getWiki(
-      @CurrentUser Long userId, @PathVariable Long projectId) {
-
-    String wiki = projectService.getWiki(projectId, userId);
-
-    return ResponseEntity.ok(
-        ApiResponse.success(
-            "wiki_fetched",
-            Map.of(
-                "wiki", wiki,
-                "project_id", projectId)));
-  }
 
   @PatchMapping("/wiki")
   public ResponseEntity<ApiResponse<?>> updateWiki(

--- a/src/main/java/com/ellu/looper/dto/ProjectResponse.java
+++ b/src/main/java/com/ellu/looper/dto/ProjectResponse.java
@@ -2,4 +2,4 @@ package com.ellu.looper.dto;
 
 import java.util.List;
 
-public record ProjectResponse(Long id, String title, String color, List<MemberDto> members) {}
+public record ProjectResponse(Long id, String title, String color, List<MemberDto> members, String wiki) {}

--- a/src/main/java/com/ellu/looper/dto/WikiRequest.java
+++ b/src/main/java/com/ellu/looper/dto/WikiRequest.java
@@ -1,6 +1,7 @@
 package com.ellu.looper.dto;
 
 import jakarta.validation.constraints.NotBlank;
+import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;

--- a/src/main/java/com/ellu/looper/entity/Project.java
+++ b/src/main/java/com/ellu/looper/entity/Project.java
@@ -37,6 +37,10 @@ public class Project {
   @Column(name = "deleted_at")
   private LocalDateTime deletedAt;
 
+  @Lob
+  @Column(columnDefinition = "TEXT")
+  private String wiki;
+
   public void setDeletedAt(LocalDateTime now) {
     this.deletedAt = now;
   }

--- a/src/main/java/com/ellu/looper/service/FastApiService.java
+++ b/src/main/java/com/ellu/looper/service/FastApiService.java
@@ -1,5 +1,6 @@
 package com.ellu.looper.service;
 
+import com.ellu.looper.commons.PreviewHolder;
 import com.ellu.looper.dto.MeetingNoteRequest;
 import com.ellu.looper.dto.MeetingNoteResponse;
 import com.ellu.looper.dto.WikiRequest;
@@ -18,6 +19,18 @@ import reactor.core.publisher.Mono;
 public class FastApiService {
 
   private final WebClient webClient;
+  private final PreviewHolder previewHolder;
+
+  // AI 서버로부터 응답을 전달받아 처리
+  public void handleAiPreviewResponse(Long projectId, MeetingNoteResponse aiResponse) {
+    // aiResponse는 AI 서버가 반환한 task preview 결과
+    previewHolder.complete(projectId, aiResponse);
+  }
+
+  // 예외 상황 처리
+  public void handleAiPreviewError(Long projectId, Throwable error) {
+    previewHolder.completeWithError(projectId, error);
+  }
 
   public void sendNoteToAI(
       MeetingNoteRequest noteRequest,

--- a/src/main/java/com/ellu/looper/service/FastApiService.java
+++ b/src/main/java/com/ellu/looper/service/FastApiService.java
@@ -48,27 +48,6 @@ public class FastApiService {
         .subscribe(onSuccess, onError);
   }
 
-  public Mono<String> getTaskPreview(Long projectId) {
-    log.info("Getting task preview from AI server for project: {}", projectId);
-    return webClient
-        .get()
-        .uri("/projects/{projectId}/tasks/preview", projectId)
-        .retrieve()
-        .bodyToMono(String.class)
-        .timeout(Duration.ofSeconds(10))
-        .doOnSuccess(
-            response -> {
-              log.info("Successfully got task preview from AI server for project: {}", projectId);
-            })
-        .doOnError(
-            error -> {
-              log.error(
-                  "Failed to get task preview from AI server for project: {}, error: {}",
-                  projectId,
-                  error.getMessage());
-            });
-  }
-
   public void createWiki(Long projectId, WikiRequest request) {
     log.info("Creating wiki for project: {}", projectId);
     webClient
@@ -92,30 +71,12 @@ public class FastApiService {
         .subscribe();
   }
 
-  public Mono<String> getWiki(Long projectId) {
-    log.info("Getting wiki for project: {}", projectId);
-    return webClient
-        .get()
-        .uri("/ai/wiki/{projectId}", projectId)
-        .retrieve()
-        .bodyToMono(String.class)
-        .timeout(Duration.ofSeconds(10))
-        .doOnSuccess(
-            response -> {
-              log.info("Successfully got wiki for project: {}", projectId);
-            })
-        .doOnError(
-            error -> {
-              log.error(
-                  "Failed to get wiki for project: {}, error: {}", projectId, error.getMessage());
-            });
-  }
 
   public void updateWiki(Long projectId, WikiRequest request) {
     log.info("Updating wiki for project: {}", projectId);
     webClient
         .patch()
-        .uri("/ai/wiki/{projectId}", projectId)
+        .uri("/ai/wiki")
         .bodyValue(request)
         .retrieve()
         .bodyToMono(Void.class)


### PR DESCRIPTION
## ☝️Issue Number
- resolve #32

## 📍 PR 타입 (하나 이상 선택)
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정

## 📌 개요 
- wiki api수정
- FE측에서 월별 일정 조회 시 현재 달과 이전 달, 다음달까지 모두 조회되게 해달라고 요청함. mvp에서는 우선 이렇게 진행하기로 함.
- long polling을 위한 api 구현

## 💌 To Reviewers
AI, FE분들 꼭 봐주세요! [회의록 업로드 long polling 흐름](https://www.notion.so/ai-be-fe-1ec177047bee80f4a733e1e9124e9ad0?showMoveTo=true&saveParent=true)
 
## ✅ 체크 리스트
- [x] 코드가 정상적으로 컴파일되는지 확인했습니다.
- [x] PR이 관련 이슈를 정확히 참조하고, 적절한 라벨을 선택했습니다.
- [ ] 모든 테스트가 성공적으로 통과했습니다.
- [ ] 관련 문서를 WIKI에 업데이트했습니다.
- [ ] 코드 스타일 가이드라인을 준수했습니다.
- [ ] 코드 리뷰어를 지정했습니다.