### PR TITLE
fix: 프로젝트 일정 수정/삭제 endpoint 수정

### DIFF
--- a/src/main/java/com/ellu/looper/controller/ProjectScheduleController.java
+++ b/src/main/java/com/ellu/looper/controller/ProjectScheduleController.java
@@ -32,7 +32,7 @@ import org.springframework.security.access.AccessDeniedException;
 import com.ellu.looper.repository.ProjectMemberRepository;
 
 @RestController
-@RequestMapping("/projects/{projectId}")
+@RequestMapping("/projects")
 @RequiredArgsConstructor
 public class ProjectScheduleController {
 
@@ -40,7 +40,7 @@ public class ProjectScheduleController {
   private final PreviewHolder previewHolder;
   private final ProjectMemberRepository projectMemberRepository;
 
-  @PostMapping("/schedules")
+  @PostMapping("/{projectId}/schedules")
   public ResponseEntity<ApiResponse<List<ProjectScheduleResponse>>> createSchedules(
       @PathVariable Long projectId,
       @RequestBody ProjectScheduleCreateRequest request,
@@ -52,23 +52,22 @@ public class ProjectScheduleController {
 
   @PatchMapping("/schedules/{scheduleId}")
   public ResponseEntity<ApiResponse<ProjectScheduleResponse>> updateSchedule(
-      @PathVariable Long projectId,
       @PathVariable Long scheduleId,
       @RequestBody ProjectScheduleUpdateRequest request,
       @CurrentUser Long userId) {
     ProjectScheduleResponse result =
-        scheduleService.updateSchedule(projectId, scheduleId, userId, request);
+        scheduleService.updateSchedule(scheduleId, userId, request);
     return ResponseEntity.ok(new ApiResponse<>("schedule_updated", result));
   }
 
   @DeleteMapping("/schedules/{scheduleId}")
   public ResponseEntity<Void> deleteSchedule(
-      @PathVariable Long projectId, @PathVariable Long scheduleId, @CurrentUser Long userId) {
+      @PathVariable Long scheduleId, @CurrentUser Long userId) {
     scheduleService.deleteSchedule(scheduleId, userId);
     return ResponseEntity.noContent().build();
   }
 
-  @GetMapping("/schedules/daily")
+  @GetMapping("/{projectId}/schedules/daily")
   public ResponseEntity<ApiResponse<?>> getDailySchedules(
       @PathVariable Long projectId,
       @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
@@ -89,7 +88,7 @@ public class ProjectScheduleController {
     return ResponseEntity.ok(new ApiResponse<>("project_daily_schedule", schedules));
   }
 
-  @GetMapping("/schedules/weekly")
+  @GetMapping("/{projectId}/schedules/weekly")
   public ResponseEntity<ApiResponse<Map<String, ?>>> getWeeklySchedules(
       @PathVariable Long projectId,
       @RequestParam(required = false, name = "startDate")
@@ -113,7 +112,7 @@ public class ProjectScheduleController {
   }
 
 
-  @GetMapping("/schedules/monthly")
+  @GetMapping("/{projectId}/schedules/monthly")
   public ResponseEntity<ApiResponse<?>> getMonthlySchedules(
       @PathVariable Long projectId,
       @RequestParam(required = false) @DateTimeFormat(pattern = "yyyy-MM") YearMonth month) {
@@ -144,7 +143,7 @@ public class ProjectScheduleController {
         new ApiResponse<>("project_monthly_schedule", flattenedSchedules));
   }
 
-  @GetMapping("/schedules/yearly")
+  @GetMapping("/{projectId}/schedules/yearly")
   public ResponseEntity<ApiResponse<?>> getYearlySchedules(
       @PathVariable Long projectId,
       @RequestParam(required = false) @DateTimeFormat(pattern = "yyyy") Year year) {
@@ -168,7 +167,7 @@ public class ProjectScheduleController {
     return ResponseEntity.ok(new ApiResponse<>("project_yearly_schedule", flattenedSchedules));
   }
 
-  @GetMapping("/tasks/preview")
+  @GetMapping("/{projectId}/tasks/preview")
   public DeferredResult<ResponseEntity<?>> getPreview(@PathVariable Long projectId,
       @CurrentUser Long userId) {
     // 프로젝트 멤버십 확인

--- a/src/main/java/com/ellu/looper/service/ProjectScheduleService.java
+++ b/src/main/java/com/ellu/looper/service/ProjectScheduleService.java
@@ -117,7 +117,7 @@ public class ProjectScheduleService {
 
   @Transactional
   public ProjectScheduleResponse updateSchedule(
-      Long projectId, Long scheduleId, Long userId, ProjectScheduleUpdateRequest request) {
+      Long scheduleId, Long userId, ProjectScheduleUpdateRequest request) {
     ProjectSchedule schedule =
         scheduleRepository
             .findByIdAndDeletedAtIsNull(scheduleId)
@@ -130,7 +130,8 @@ public class ProjectScheduleService {
     validateTimeOrder(request.start_time(), request.end_time());
 
     schedule.update(
-        request.title(), null, request.start_time(), request.end_time(), request.completed());
+        request.title(), request.description(), request.start_time(), request.end_time(),
+        request.completed());
     return new ProjectScheduleResponse(
         schedule.getId(),
         schedule.getTitle(),
@@ -147,11 +148,9 @@ public class ProjectScheduleService {
         scheduleRepository
             .findByIdAndDeletedAtIsNull(scheduleId)
             .orElseThrow(() -> new IllegalArgumentException("Schedule not found"));
-
     if (!schedule.getUser().getId().equals(userId)) {
       throw new AccessDeniedException("Unauthorized");
     }
-
     schedule.softDelete();
   }
 


### PR DESCRIPTION

## 📍 PR 타입 (하나 이상 선택)
- [ ] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [x] 기타 사소한 수정

## 📌 개요
### 프로젝트 일정 수정/삭제 Endpoint 구조 변경

기존에는 프로젝트 일정 수정 및 삭제 시 `/projects/{projectId}/schedules/{scheduleId}`와 같은 RESTful한 URI 구조를 따랐습니다.

그러나 실제 사용 흐름에서는 클라이언트가 `projectId` 없이도 `scheduleId`만으로 일정의 종류(개인/프로젝트)를 구분할 수 있으며, 이를 바탕으로 백엔드에서도 올바른 처리가 가능하다는 점을 고려해 Endpoint 구조를 단순화했습니다.

이에 따라 다음과 같이 URI를 변경했습니다:

* **Before:** `DELETE /projects/{projectId}/schedules/{scheduleId}`
* **After:** `DELETE /projects/schedules/{scheduleId}`

또한, 개인 일정 조회가 `/user/{userId}/schedules/{id}`가 아닌 `/user/schedules/{id}` 형태로 이루어지고 있는 점을 고려하여, 프로젝트 일정 역시 `projectId` 없이 `scheduleId`만으로 처리함으로써 **엔드포인트 구조의 일관성**을 유지했습니다.

---

### 설계 배경 및 이점

**1. 스케줄 ID만으로 충분한 식별 가능**

* 프로젝트 일정과 개인 일정은 서로 다른 테이블에서 관리되며, 각 테이블 내에서 `scheduleId`는 고유합니다.
* 따라서 단일 `scheduleId`만으로도 백엔드에서 해당 일정의 종류를 판별하고 처리할 수 있어 `projectId`를 추가로 받을 필요가 없습니다.

**2. 클라이언트 구현 및 유지보수 단순화**

* 클라이언트 측에서 일정 삭제/수정 시 별도로 `projectId`를 관리하거나 전달할 필요가 없기 때문에 구현이 단순해지고, 일정 관리 로직의 유지보수도 쉬워집니다.



## ✅ 체크 리스트
- [x] 코드가 정상적으로 컴파일되는지 확인했습니다.
- [x] PR이 관련 이슈를 정확히 참조하고, 적절한 라벨을 선택했습니다.
- [ ] 모든 테스트가 성공적으로 통과했습니다.
- [ ] 관련 문서를 WIKI에 업데이트했습니다.
- [ ] 코드 스타일 가이드라인을 준수했습니다.
- [ ] 코드 리뷰어를 지정했습니다.