### PR TITLE
fix: 비동기 처리 추가 및 개발 환경 쿠키 설정 추가

### DIFF
--- a/src/main/java/com/ellu/looper/commons/ScheduleHolder.java
+++ b/src/main/java/com/ellu/looper/commons/ScheduleHolder.java
@@ -1,0 +1,76 @@
+package com.ellu.looper.commons;
+
+import com.ellu.looper.dto.schedule.ProjectScheduleCreateRequest;
+import com.ellu.looper.dto.schedule.ProjectScheduleResponse;
+import com.ellu.looper.service.ProjectScheduleService;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.web.context.request.async.DeferredResult;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ScheduleHolder {
+
+  private final Map<String, DeferredResult<ResponseEntity<?>>> waitingClients = new ConcurrentHashMap<>();
+  private final ProjectScheduleService scheduleService;
+
+  public void register(Long projectId, Long userId, ProjectScheduleCreateRequest request,
+      DeferredResult<ResponseEntity<?>> result) {
+    String key = generateKey(projectId, userId);
+    log.info("[ScheduleHolder] Registering schedule creation request for key: {}", key);
+    waitingClients.put(key,
+        result);    // 비동기 처리 시작
+    CompletableFuture.runAsync(() -> {
+      try {
+        log.info("[ScheduleHolder] Starting async schedule creation for key: {}", key);
+        List<ProjectScheduleResponse> schedules = scheduleService.createSchedules(projectId, userId,
+            request);
+        complete(projectId, userId, schedules);
+      } catch (Exception e) {
+        log.error("[ScheduleHolder] Error during async schedule creation for key: {}, error: {}",
+            key, e.getMessage(), e);
+        completeWithError(projectId, userId, e);
+      }
+    });
+  }
+
+  public void complete(Long projectId, Long userId, List<ProjectScheduleResponse> response) {
+    String key = generateKey(projectId, userId);
+    log.info("[ScheduleHolder] Completing schedule creation for key: {}", key);
+    DeferredResult<ResponseEntity<?>> result = waitingClients.remove(key);
+    if (result != null && !result.isSetOrExpired()) {
+      log.info("[ScheduleHolder] Setting successful result for key: {}", key);
+      result.setResult(ResponseEntity.ok(ApiResponse.success("project_daily_schedule", response)));
+    } else {
+      log.warn("[ScheduleHolder] No waiting client found or result already set for key: {}", key);
+    }
+  }
+
+  public void completeWithError(Long projectId, Long userId, Throwable error) {
+    String key = generateKey(projectId, userId);
+    log.error("[ScheduleHolder] Completing with error for key: {}, error: {}", key,
+        error.getMessage(), error);
+    DeferredResult<ResponseEntity<?>> result = waitingClients.remove(key);
+    if (result != null) {
+      result.setResult(
+          ResponseEntity.internalServerError().body(ApiResponse.error("internal_server_error")));
+    }
+  }
+
+  public void remove(Long projectId, Long userId) {
+    String key = generateKey(projectId, userId);
+    log.info("[ScheduleHolder] Removing schedule holder for key: {}", key);
+    waitingClients.remove(key);
+  }
+
+  private String generateKey(Long projectId, Long userId) {
+    return projectId + ":" + userId;
+  }
+}

--- a/src/main/java/com/ellu/looper/config/SecurityConfig.java
+++ b/src/main/java/com/ellu/looper/config/SecurityConfig.java
@@ -39,6 +39,7 @@ public class SecurityConfig {
                     .requestMatchers(HttpMethod.OPTIONS, "/**")
                     .permitAll() // Preflight 요청 허용
                     .requestMatchers(HttpMethod.GET, "/projects/*/tasks/preview").permitAll()
+                    .requestMatchers(HttpMethod.POST, "/projects/*/schedules").permitAll()
                     .anyRequest()
                     .authenticated() // 나머지는 인증 필요
             )

--- a/src/main/java/com/ellu/looper/controller/ProjectScheduleController.java
+++ b/src/main/java/com/ellu/looper/controller/ProjectScheduleController.java
@@ -3,6 +3,7 @@ package com.ellu.looper.controller;
 import com.ellu.looper.commons.ApiResponse;
 import com.ellu.looper.commons.CurrentUser;
 import com.ellu.looper.commons.PreviewHolder;
+import com.ellu.looper.commons.ScheduleHolder;
 import com.ellu.looper.dto.schedule.ProjectScheduleCreateRequest;
 import com.ellu.looper.dto.schedule.ProjectScheduleResponse;
 import com.ellu.looper.dto.schedule.ProjectScheduleUpdateRequest;
@@ -38,16 +39,30 @@ public class ProjectScheduleController {
 
   private final ProjectScheduleService scheduleService;
   private final PreviewHolder previewHolder;
+  private final ScheduleHolder scheduleHolder;
   private final ProjectMemberRepository projectMemberRepository;
 
   @PostMapping("/{projectId}/schedules")
-  public ResponseEntity<ApiResponse<List<ProjectScheduleResponse>>> createSchedules(
-      @PathVariable Long projectId,
+  public DeferredResult<ResponseEntity<?>> createSchedules(@PathVariable Long projectId,
       @RequestBody ProjectScheduleCreateRequest request,
-      @CurrentUser Long userId) {
-    List<ProjectScheduleResponse> result =
-        scheduleService.createSchedules(projectId, userId, request);
-    return ResponseEntity.ok(new ApiResponse<>("project_daily_schedule", result));
+      @CurrentUser Long userId) {    // 프로젝트 멤버인지 확인    
+    projectMemberRepository.findByProjectIdAndUserId(projectId, userId)
+        .orElseThrow(() -> new AccessDeniedException("Not a member of this project"));
+    DeferredResult<ResponseEntity<?>> result = new DeferredResult<>(300000L); // 5분 타임아웃
+    // 요청 등록    
+    scheduleHolder.register(projectId, userId, request, result);
+    result.onTimeout(() -> {
+      scheduleHolder.remove(projectId, userId);
+      result.setResult(ResponseEntity.status(HttpStatus.ACCEPTED).body(
+          ApiResponse.success("still_processing", Map.of("message",
+              "Schedule creation is still processing.", "data", List.of()))));
+    });
+    result.onError((error) -> {
+      scheduleHolder.remove(projectId, userId);
+      result.setResult(ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(
+          ApiResponse.error("internal_server_error")));
+    });
+    return result;
   }
 
   @PatchMapping("/schedules/{scheduleId}")

--- a/src/main/java/com/ellu/looper/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/ellu/looper/jwt/JwtAuthenticationFilter.java
@@ -8,6 +8,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -21,6 +22,10 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
   private final JwtProvider jwtProvider;
   private final JwtService jwtService;
+  @Value("${spring.application.mode}")
+  private String devEnv;
+  @Value("${cookie.secure}")
+  private boolean useHttps;
 
   public JwtAuthenticationFilter(JwtProvider jwtProvider, JwtService jwtService) {
     this.jwtProvider = jwtProvider;
@@ -60,7 +65,6 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         }
       }
     }
-
     filterChain.doFilter(request, response);
   }
 
@@ -103,12 +107,14 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
   }
 
   private void setRefreshTokenCookie(HttpServletResponse response, String refreshToken) {
+    boolean isProduction = "production".equals(devEnv);
+    boolean shouldUseSecure = isProduction && useHttps;
+    String sameSite = shouldUseSecure ? "None" : "Lax";
     Cookie refreshCookie = new Cookie("refresh_token", refreshToken);
-    refreshCookie.setHttpOnly(true);
-    refreshCookie.setSecure(true);
+    refreshCookie.setHttpOnly(useHttps);
+    refreshCookie.setSecure(shouldUseSecure);
     refreshCookie.setPath("/");
     refreshCookie.setMaxAge((int) JwtExpiration.REFRESH_TOKEN_EXPIRATION);
-
     response.addCookie(refreshCookie);
   }
 }

--- a/src/main/java/com/ellu/looper/service/AuthService.java
+++ b/src/main/java/com/ellu/looper/service/AuthService.java
@@ -18,6 +18,7 @@ import jakarta.servlet.http.HttpServletResponse;
 import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseCookie;
 import org.springframework.stereotype.Service;
@@ -33,6 +34,10 @@ public class AuthService {
   private final JwtProvider jwtProvider;
   private final RefreshTokenRepository refreshTokenRepository;
   private final ProfileImageService profileImageService;
+  @Value("${spring.application.mode}")
+  private String devEnv;
+  @Value("${cookie.secure}")
+  private boolean useHttps;
 
   @Transactional
   public AuthResponse loginOrSignUp(String provider, String accessToken) {
@@ -139,12 +144,11 @@ public class AuthService {
       savedToken.updateToken(newRefreshToken);
 
       // HttpOnly 쿠키로 새 refresh token 전달
-      Cookie refreshTokenCookie = new Cookie("refresh_token", newRefreshToken);
-      refreshTokenCookie.setHttpOnly(true);
-      refreshTokenCookie.setSecure(true); // HTTPS 환경에서만 true
-      refreshTokenCookie.setPath("/");
-      refreshTokenCookie.setMaxAge((int)(JwtExpiration.REFRESH_TOKEN_EXPIRATION / 1000));
-      response.addCookie(refreshTokenCookie);
+      boolean isProduction = "production".equals(devEnv);
+      boolean shouldUseSecure = isProduction && useHttps;
+      String sameSite = shouldUseSecure ? "None" : "Lax";
+
+      setTokenCookies(response, newRefreshToken);
     }
 
     User user = userRepository.findById(userId)
@@ -159,10 +163,13 @@ public class AuthService {
 
 
   public void setTokenCookies(HttpServletResponse response, String refreshToken) {
+    boolean isProduction = "production".equals(devEnv);
+    boolean shouldUseSecure = isProduction && useHttps;
+    String sameSite = shouldUseSecure ? "None" : "Lax";
     ResponseCookie refreshCookie = ResponseCookie.from("refresh_token", refreshToken)
-        .httpOnly(true)
-        .secure(true)
-        .sameSite("None")
+        .httpOnly(useHttps)
+        .secure(shouldUseSecure)
+        .sameSite(sameSite)
         .path("/")
         .maxAge(JwtExpiration.REFRESH_TOKEN_EXPIRATION)
         .build();

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -3,6 +3,7 @@ spring:
     import: optional:dotenv:.env
   application:
     name: looper
+    mode: ${DEV_ENV:development}
   datasource:
     url: ${DB_URL:jdbc:postgresql://localhost:5433/looperdb_main_dev}
     username: ${DB_USERNAME}
@@ -57,3 +58,6 @@ info:
     name: ${spring.application.name}
     version: 1.0.1
     description: Looper API 서버
+
+cookie:
+  secure: ${USE_HTTPS:false}


### PR DESCRIPTION
## ☝️Issue Number
- resolve #59

## 📍 PR 타입 (하나 이상 선택)
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정

## 📌 개요
비동기 처리 추가 및 개발 환경 쿠키 설정 추가-> stage환경과 개발 환경의 쿠키 설정이 다름
```
 public void setTokenCookies(HttpServletResponse response, String refreshToken) {
    boolean isProduction = "production".equals(devEnv);
    boolean shouldUseSecure = isProduction && useHttps;
    String sameSite = shouldUseSecure ? "None" : "Lax";
    ResponseCookie refreshCookie = ResponseCookie.from("refresh_token", refreshToken)
        .httpOnly(useHttps)
        .secure(shouldUseSecure)
        .sameSite(sameSite)
        .path("/")
        .maxAge(JwtExpiration.REFRESH_TOKEN_EXPIRATION)
        .build();
``` 

## ✅ 체크 리스트
- [x] 코드가 정상적으로 컴파일되는지 확인했습니다.
- [x] PR이 관련 이슈를 정확히 참조하고, 적절한 라벨을 선택했습니다.
- [ ] 모든 테스트가 성공적으로 통과했습니다.
- [ ] 관련 문서를 WIKI에 업데이트했습니다.
- [ ] 코드 스타일 가이드라인을 준수했습니다.
- [ ] 코드 리뷰어를 지정했습니다.