### PR TITLE
fix: kafka topic 명시적 생성

### DIFF
--- a/src/main/java/com/ellu/looper/kafka/KafkaTopicConfig.java
+++ b/src/main/java/com/ellu/looper/kafka/KafkaTopicConfig.java
@@ -1,0 +1,29 @@
+package com.ellu.looper.kafka;
+
+
+import org.apache.kafka.clients.admin.NewTopic;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class KafkaTopicConfig {
+
+
+  @Value("${kafka.topics.chatbot.user-input}")
+  private String USER_INPUT_TOPIC;
+
+  @Value("${kafka.topics.chatbot.response}")
+  private String RESPONSE_TOPIC;
+
+  @Bean
+  public NewTopic chatTopic() {
+    return new NewTopic("test1", 3, (short) 1);
+  }
+
+  @Bean
+  public NewTopic responseTopic() {
+    return new NewTopic("test2", 3, (short) 1);
+  }
+
+}


### PR DESCRIPTION


## 📍 PR 타입 (하나 이상 선택)
- [ ] 기능 추가
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정

## 📌 개요
- kafka streams를 사용하기 위해 토픽을 명시적으로 생성하는 코드를 추가함

## ✅ 체크 리스트
- [x] 코드가 정상적으로 컴파일되는지 확인했습니다.
- [x] PR이 관련 이슈를 정확히 참조하고, 적절한 라벨을 선택했습니다.
- [ ] 모든 테스트가 성공적으로 통과했습니다.
- [ ] 관련 문서를 WIKI에 업데이트했습니다.
- [ ] 코드 스타일 가이드라인을 준수했습니다.
- [ ] 코드 리뷰어를 지정했습니다.