### PR TITLE
Fix: 회의록 기반 태스크 추출 기능 수정

### DIFF
--- a/src/main/java/com/ellu/looper/fastapi/controller/FastApiCallbackController.java
+++ b/src/main/java/com/ellu/looper/fastapi/controller/FastApiCallbackController.java
@@ -3,6 +3,7 @@ package com.ellu.looper.fastapi.controller;
 import com.ellu.looper.fastapi.dto.MeetingNoteResponse;
 import com.ellu.looper.fastapi.dto.WikiEmbeddingResponse;
 import com.ellu.looper.fastapi.service.FastApiService;
+import com.ellu.looper.kafka.PreviewResultProducer;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
@@ -22,6 +23,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class FastApiCallbackController {
 
   private final FastApiService aiCallbackService;
+  private final PreviewResultProducer previewResultProducer;
 
   @PostMapping("/projects/{projectId}/preview")
   public ResponseEntity<?> receiveAiPreview(
@@ -42,7 +44,8 @@ public class FastApiCallbackController {
       log.warn("[FastApiCallbackController] No data received in the response");
     }
 
-    aiCallbackService.handleAiPreviewResponse(projectId, aiPreviewResponse);
+    // Kafka를 통해 메시지 전달
+    previewResultProducer.sendPreviewResult(projectId, aiPreviewResponse);
 
     log.info(
         "[FastApiCallbackController] Successfully processed callback for project: {}", projectId);

--- a/src/main/java/com/ellu/looper/fastapi/service/FastApiService.java
+++ b/src/main/java/com/ellu/looper/fastapi/service/FastApiService.java
@@ -6,7 +6,6 @@ import com.ellu.looper.commons.enums.NotificationType;
 import com.ellu.looper.fastapi.dto.MeetingNoteRequest;
 import com.ellu.looper.fastapi.dto.MeetingNoteResponse;
 import com.ellu.looper.fastapi.dto.WikiEmbeddingResponse;
-import com.ellu.looper.kafka.PreviewResultProducer;
 import com.ellu.looper.notification.service.NotificationService;
 import com.ellu.looper.project.dto.WikiRequest;
 import com.ellu.looper.project.entity.Project;
@@ -33,30 +32,6 @@ public class FastApiService {
   private final NotificationService notificationService;
   private final ProjectRepository projectRepository;
   private final ProjectMemberRepository projectMemberRepository;
-  private final PreviewResultProducer previewResultProducer;
-
-  // AI 서버로부터 응답을 전달받아 처리
-  public void handleAiPreviewResponse(Long projectId, MeetingNoteResponse aiResponse) {
-    log.info("[FastApiService] Handling AI preview response for project: {}", projectId);
-
-    if (aiResponse.getDetail() != null) {
-      aiResponse
-          .getDetail()
-          .forEach(
-              preview -> {
-                log.info("[FastApiService] Task: {}", preview.getTask());
-                log.info("[FastApiService] Subtasks: {}", preview.getSubtasks());
-              });
-    } else {
-      log.warn("[FastApiService] No data received in the response");
-    }
-
-    // 분산 처리를 위해 Kafka에 메시지 발행
-    previewResultProducer.sendPreviewResult(projectId, aiResponse);
-
-    log.info(
-        "[FastApiService] Successfully handled AI preview response for project: {}", projectId);
-  }
 
   public void handleWikiEmbeddingCompletion(
       Long projectId, WikiEmbeddingResponse wikiEmbeddingResponse) {

--- a/src/main/java/com/ellu/looper/kafka/PreviewResultConsumer.java
+++ b/src/main/java/com/ellu/looper/kafka/PreviewResultConsumer.java
@@ -6,6 +6,9 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.support.KafkaHeaders;
+import org.springframework.messaging.handler.annotation.Header;
+import org.springframework.messaging.handler.annotation.Payload;
 import org.springframework.stereotype.Component;
 
 @Slf4j
@@ -19,7 +22,8 @@ public class PreviewResultConsumer {
   private String previewResultTopic;
 
   @KafkaListener(topics = "${kafka.topics.preview}", groupId = "${kafka.consumer.preview-group-id}")
-  public void consumePreviewResult(String projectId, MeetingNoteResponse response) {
+  public void consumePreviewResult(
+      @Header(KafkaHeaders.RECEIVED_KEY) String projectId, @Payload MeetingNoteResponse response) {
     log.info("[PreviewResultConsumer] Received preview result for project: {}", projectId);
     previewHolder.complete(Long.parseLong(projectId), response);
     log.info(

--- a/src/main/java/com/ellu/looper/kafka/PreviewResultProducer.java
+++ b/src/main/java/com/ellu/looper/kafka/PreviewResultProducer.java
@@ -19,7 +19,16 @@ public class PreviewResultProducer {
 
   public void sendPreviewResult(Long projectId, MeetingNoteResponse response) {
     log.info("[PreviewResultProducer] Sending preview result for project: {}", projectId);
-    kafkaTemplate.send(previewResultTopic, projectId.toString(), response);
-    log.info("[PreviewResultProducer] Successfully sent preview result for project: {}", projectId);
+    try {
+      kafkaTemplate.send(previewResultTopic, projectId.toString(), response);
+      log.info(
+          "[PreviewResultProducer] Successfully sent preview result for project: {}", projectId);
+    } catch (Exception e) {
+      log.error(
+          "[PreviewResultProducer] Failed to send preview result for project: {}, error: {}",
+          projectId,
+          e.getMessage(),
+          e);
+    }
   }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -23,8 +23,8 @@ spring:
     consumer:
       key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
       value-deserializer: org.springframework.kafka.support.serializer.JsonDeserializer
-#      properties:
-#        spring.json.trusted.packages: com.ellu.looper.chat.dto
+      properties:
+        spring.json.trusted.packages: "*"
     streams:
       bootstrap-servers: ${KAFKA_BASE_URL:localhost:9092}
       application-id: looper-streams-app


### PR DESCRIPTION
## ☝️Issue Number
- resolve #119

## 📍 PR 타입 (하나 이상 선택) 
- [x] 버그 수정 

## 📌 개요
- 수정된 구조: FastAPI → FastApiCallbackController (Kafka로 발행) → Kafka → PreviewResultConsumer (Kafka 메시지 소비) → PreviewHolder (클라이언트에게 응답 전달) → Frontend

- 버그 내용
  - 문제의 핵심은 동일한 프로젝트에 대한 응답이 두 번 처리되려고 시도한다는 것이었음.
  - FastApiCallbackController가 FastAPI로부터 콜백을 받아 먼저 응답을 처리하고, 이 과정에서 PreviewHolder가 해당 프로젝트 ID에 해당하는 기다리는 클라이언트(프론트엔드)에게 응답을 전달하고는 해당 클라이언트 세션을 종료하면서 제거함.
  - 이후 PreviewResultConsumer가 Kafka로부터 동일한 프로젝트 ID에 대한 메시지를 받아서 다시 PreviewHolder를 통해 응답을 처리하려고 할 때, 이미 FastApiCallbackController에서 처리하여 클라이언트 세션이 제거되었으므로, PreviewHolder는 `"No waiting client found"`라는 로그가 찍히면서 더 이상 전달할 클라이언트를 찾지 못했음
  - 결론적으로, 프론트엔드에 제대로 전송이 안 된것은 FastApiCallbackController에서 응답을 이미 처리했기 때문에 Kafka를 통한 두 번째 처리 시점에서는 이미 클라이언트가 존재하지 않아 경고가 발생한 것이었음



## ✅ 체크 리스트
- [x] 코드가 정상적으로 컴파일되는지 확인했습니다.
- [x] PR이 관련 이슈를 정확히 참조하고, 적절한 라벨을 선택했습니다.
- [ ] 모든 테스트가 성공적으로 통과했습니다.
- [ ] 관련 문서를 WIKI에 업데이트했습니다.
- [ ] 코드 스타일 가이드라인을 준수했습니다.
- [ ] 코드 리뷰어를 지정했습니다.