### PR TITLE
feat: 프로젝트 멤버들도 프로젝트 색상 조회 가능하게 수정

### DIFF
--- a/src/main/java/com/ellu/looper/project/service/ProjectService.java
+++ b/src/main/java/com/ellu/looper/project/service/ProjectService.java
@@ -204,7 +204,7 @@ public class ProjectService {
             .orElseThrow(() -> new IllegalArgumentException("Project not found"));
 
     if (!project.getMember().getId().equals(userId)) {
-      throw new SecurityException("Only project creator can view this project");
+      return new CreatorExcludedProjectResponse(project.getId(), project.getTitle(), project.getColor().name(), null, null, null);
     }
 
     List<ProjectMember> members = projectMemberRepository.findByProjectAndDeletedAtIsNull(project);


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [ ] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [x] 기타 사소한 수정

## 📌 개요
-  프로젝트 멤버들이 공유 캘린더(프로젝트 캘린더)에서 일정을 생성할 때 프로젝트 색상이 필요하므로, 프로젝트 정보(색상,제목,프로젝트 id)를 조회 가능하게 수정

## ✅ 체크 리스트
- [x] 코드가 정상적으로 컴파일되는지 확인했습니다.
- [x] PR이 관련 이슈를 정확히 참조하고, 적절한 라벨을 선택했습니다.
- [ ] 모든 테스트가 성공적으로 통과했습니다.
- [ ] 관련 문서를 WIKI에 업데이트했습니다.
- [ ] 코드 스타일 가이드라인을 준수했습니다.
- [ ] 코드 리뷰어를 지정했습니다.