### PR TITLE
refactor: 프로젝트 목록 조회 시 N+1 문제 해결

### DIFF
--- a/src/main/java/com/ellu/looper/project/repository/ProjectMemberRepository.java
+++ b/src/main/java/com/ellu/looper/project/repository/ProjectMemberRepository.java
@@ -5,13 +5,24 @@ import com.ellu.looper.project.entity.ProjectMember;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface ProjectMemberRepository extends JpaRepository<ProjectMember, Long> {
 
   // 로그인한 사용자가 참여한 모든 프로젝트 멤버십 조회 (soft-delete 제외)
-  List<ProjectMember> findByUserIdAndDeletedAtIsNull(Long userId);
+  @Query("SELECT pm FROM ProjectMember pm " +
+      "JOIN FETCH pm.project p " +
+      "JOIN FETCH pm.user u " +
+      "WHERE u.id = :userId AND pm.deletedAt IS NULL")
+  List<ProjectMember> findWithProjectAndUserByUserId(@Param("userId") Long userId);
+
+  @Query("SELECT pm FROM ProjectMember pm " +
+      "JOIN FETCH pm.user u " +
+      "WHERE pm.project.id IN :projectIds AND pm.deletedAt IS NULL")
+  List<ProjectMember> findByProjectIdsWithUser(@Param("projectIds") List<Long> projectIds);
 
   // 특정 프로젝트의 멤버들 조회 (soft-delete 제외)
   List<ProjectMember> findByProjectAndDeletedAtIsNull(Project project);
@@ -26,3 +37,4 @@ public interface ProjectMemberRepository extends JpaRepository<ProjectMember, Lo
 
   boolean existsByProjectIdAndUserIdAndDeletedAtIsNull(Long id, Long userId);
 }
+


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [x] 리팩토링


## ✅ 체크 리스트
- [x] 코드가 정상적으로 컴파일되는지 확인했습니다.
- [x] PR이 관련 이슈를 정확히 참조하고, 적절한 라벨을 선택했습니다.
- [ ] 모든 테스트가 성공적으로 통과했습니다.
- [ ] 관련 문서를 WIKI에 업데이트했습니다.
- [ ] 코드 스타일 가이드라인을 준수했습니다.
- [ ] 코드 리뷰어를 지정했습니다.

## 📌 개요
## 해결해야 하는 이유

- **DB round-trip 감소**
- **쿼리 수 감소** → DB 커넥션 풀에 부담 줄어든다
- **트래픽량 감소** → ORM이 반복적으로 데이터를 가져오는 오버헤드 줄어든다

## 원인
### 기존 코드 흐름:

1. `projectMemberRepository.findByUserIdAndDeletedAtIsNull(userId)`
    
    → 이 쿼리에서 사용자의 프로젝트 멤버십들을 가져옵니다.
    
2. 각 `ProjectMember`에서 `getProject()` 호출
    
    → `project_id`를 기반으로 프로젝트를 Lazy Loading 하므로 `N`개의 쿼리 발생.
    
3. 그 `Project`들에 대해 또 다시 `projectMemberRepository.findByProjectAndDeletedAtIsNull(project)`
    
    → 프로젝트마다 멤버 리스트 가져오니 또 `N`개의 쿼리 발생.
    
4. 그리고 각 `ProjectMember.getUser()`
    
    → 멤버 수 만큼 `User`도 Lazy Loading 되면서 `N`개의 쿼리 추가.
    

엔티티 연관 관계들이 모두 `@ManyToOne(fetch = FetchType.LAZY)`인데, 서비스 레이어에서 반복적으로 `getProject()`, `getUser()`를 호출하면서 Hibernate가 한 번에 못 불러오고 하나씩 추가 쿼리를 날림.

### **N+1 상황 시나리오**

- `N = 프로젝트 수`
    
    → 프로젝트 2개면 최소 다음 쿼리 수 발생:
    
    ```
    1 (유저의 projectMember들) +
    2 (각 project Lazy loading) +
    2 (각 project의 member 리스트) +
    2 (각 멤버의 User 객체) =
    총 7개
    
    ```
    

## 해결 : Fetch Join 사용 (JPQL로 직접 조회)

### 1. Project와 User 가져오기

```java
@Query("SELECT pm FROM ProjectMember pm " +
       "JOIN FETCH pm.project p " +
       "JOIN FETCH pm.user u " +
       "WHERE u.id = :userId AND pm.deletedAt IS NULL")
List<ProjectMember> findWithProjectAndUserByUserId(@Param("userId") Long userId);

```

 사용자가 속한 `ProjectMember`를 가져오면서  `Project`와 `User`를 모두 `fetch join`으로 가져옴.

### 2. **프로젝트 멤버들 미리 불러오기**

`projectMemberRepository.findByProjectAndDeletedAtIsNull(project)` 를 루프 내에서 호출하면 또 N+1 문제가 발생

```java
@Query("SELECT pm FROM ProjectMember pm " +
       "JOIN FETCH pm.user u " +
       "WHERE pm.project.id IN :projectIds AND pm.deletedAt IS NULL")
List<ProjectMember> findByProjectIdsWithUser(@Param("projectIds") List<Long> projectIds);

```

해당 `Project`들에 속한 **모든 멤버**를 가져오고, `User`를 함께 불러옴. 그 후 `projectId` 를 기준으로 `Map<ProjectId, List<ProjectMember>>` 형태로 groupBy 해서 response로 반환

## 결과

쿼리는 고정된 2개로 끝나고, 프로젝트 수나 멤버 수에 따라 쿼리 수가 선형적으로 증가하지 않음.

### 1. 사용자 기준 프로젝트 조회

```sql
SELECT pm
FROM ProjectMember pm
JOIN FETCH pm.project p
JOIN FETCH pm.user u
WHERE u.id = :userId
AND pm.deletedAt IS NULL
```

- 사용자가 속한 모든 프로젝트 멤버십을 가져오고 `ProjectMember`에 연관된 `Project`, `User`를 모두 한 번에 fetch join 함 

### 2. 해당 프로젝트의 전체 멤버 조회

```sql
SELECT pm
FROM ProjectMember pm
JOIN FETCH pm.user u
WHERE pm.project.id IN :projectIds
AND pm.deletedAt IS NULL
```

- 프로젝트의 모든 멤버를 가져오기 위한 쿼리고, `User`도 fetch join 되어 있어 루프마다 추가로 불러오는 일은 없음.

이전

```sql
2025-06-23T16:44:27.071+09:00  INFO 19789 --- [looper] [nio-8080-exec-7] c.e.l.project.service.ProjectService     : Getting projects for user: 1
[Hibernate] 
    /* <criteria> */ select
        pm1_0.id,
        pm1_0.created_at,
        pm1_0.deleted_at,
        pm1_0.position,
        pm1_0.project_id,
        pm1_0.role,
        pm1_0.updated_at,
        pm1_0.member_id 
    from
        project_member pm1_0 
    left join
        member u1_0 
            on u1_0.id=pm1_0.member_id 
    where
        u1_0.id=? 
        and pm1_0.deleted_at is null
2025-06-23T16:44:27.073+09:00  INFO 19789 --- [looper] [nio-8080-exec-7] p6spy                                    : #1750664667073 | took 0ms | statement | connection 6| url jdbc:postgresql://localhost:5433/looperdb_main_dev
/* <criteria> */ select pm1_0.id,pm1_0.created_at,pm1_0.deleted_at,pm1_0.position,pm1_0.project_id,pm1_0.role,pm1_0.updated_at,pm1_0.member_id from project_member pm1_0 left join member u1_0 on u1_0.id=pm1_0.member_id where u1_0.id=? and pm1_0.deleted_at is null
/* <criteria> */ select pm1_0.id,pm1_0.created_at,pm1_0.deleted_at,pm1_0.position,pm1_0.project_id,pm1_0.role,pm1_0.updated_at,pm1_0.member_id from project_member pm1_0 left join member u1_0 on u1_0.id=pm1_0.member_id where u1_0.id=1 and pm1_0.deleted_at is null;
[Hibernate] 
    select
        p1_0.id,
        p1_0.color,
        p1_0.created_at,
        p1_0.deleted_at,
        p1_0.member_id,
        p1_0.title,
        p1_0.updated_at,
        p1_0.wiki 
    from
        project p1_0 
    where
        p1_0.id=?
2025-06-23T16:44:27.074+09:00  INFO 19789 --- [looper] [nio-8080-exec-7] p6spy                                    : #1750664667074 | took 0ms | statement | connection 6| url jdbc:postgresql://localhost:5433/looperdb_main_dev
select p1_0.id,p1_0.color,p1_0.created_at,p1_0.deleted_at,p1_0.member_id,p1_0.title,p1_0.updated_at,p1_0.wiki from project p1_0 where p1_0.id=?
select p1_0.id,p1_0.color,p1_0.created_at,p1_0.deleted_at,p1_0.member_id,p1_0.title,p1_0.updated_at,p1_0.wiki from project p1_0 where p1_0.id=1;
[Hibernate] 
    /* <criteria> */ select
        pm1_0.id,
        pm1_0.created_at,
        pm1_0.deleted_at,
        pm1_0.position,
        pm1_0.project_id,
        pm1_0.role,
        pm1_0.updated_at,
        pm1_0.member_id 
    from
        project_member pm1_0 
    where
        pm1_0.project_id=? 
        and pm1_0.deleted_at is null
2025-06-23T16:44:27.076+09:00  INFO 19789 --- [looper] [nio-8080-exec-7] p6spy                                    : #1750664667076 | took 0ms | statement | connection 6| url jdbc:postgresql://localhost:5433/looperdb_main_dev
/* <criteria> */ select pm1_0.id,pm1_0.created_at,pm1_0.deleted_at,pm1_0.position,pm1_0.project_id,pm1_0.role,pm1_0.updated_at,pm1_0.member_id from project_member pm1_0 where pm1_0.project_id=? and pm1_0.deleted_at is null
/* <criteria> */ select pm1_0.id,pm1_0.created_at,pm1_0.deleted_at,pm1_0.position,pm1_0.project_id,pm1_0.role,pm1_0.updated_at,pm1_0.member_id from project_member pm1_0 where pm1_0.project_id=1 and pm1_0.deleted_at is null;
[Hibernate] 
    select
        u1_0.id,
        u1_0.created_at,
        u1_0.deleted_at,
        u1_0.email,
        u1_0.file_name,
        u1_0.nickname,
        u1_0.nickname_choseong,
        u1_0.provider,
        u1_0.provider_id,
        u1_0.updated_at 
    from
        member u1_0 
    where
        u1_0.id=?
2025-06-23T16:44:27.077+09:00  INFO 19789 --- [looper] [nio-8080-exec-7] p6spy                                    : #1750664667077 | took 0ms | statement | connection 6| url jdbc:postgresql://localhost:5433/looperdb_main_dev
select u1_0.id,u1_0.created_at,u1_0.deleted_at,u1_0.email,u1_0.file_name,u1_0.nickname,u1_0.nickname_choseong,u1_0.provider,u1_0.provider_id,u1_0.updated_at from member u1_0 where u1_0.id=?
select u1_0.id,u1_0.created_at,u1_0.deleted_at,u1_0.email,u1_0.file_name,u1_0.nickname,u1_0.nickname_choseong,u1_0.provider,u1_0.provider_id,u1_0.updated_at from member u1_0 where u1_0.id=1;
[Hibernate] 
    select
        u1_0.id,
        u1_0.created_at,
        u1_0.deleted_at,
        u1_0.email,
        u1_0.file_name,
        u1_0.nickname,
        u1_0.nickname_choseong,
        u1_0.provider,
        u1_0.provider_id,
        u1_0.updated_at 
    from
        member u1_0 
    where
        u1_0.id=?
2025-06-23T16:44:27.078+09:00  INFO 19789 --- [looper] [nio-8080-exec-7] p6spy                                    : #1750664667078 | took 0ms | statement | connection 6| url jdbc:postgresql://localhost:5433/looperdb_main_dev
select u1_0.id,u1_0.created_at,u1_0.deleted_at,u1_0.email,u1_0.file_name,u1_0.nickname,u1_0.nickname_choseong,u1_0.provider,u1_0.provider_id,u1_0.updated_at from member u1_0 where u1_0.id=?
select u1_0.id,u1_0.created_at,u1_0.deleted_at,u1_0.email,u1_0.file_name,u1_0.nickname,u1_0.nickname_choseong,u1_0.provider,u1_0.provider_id,u1_0.updated_at from member u1_0 where u1_0.id=3;
2025-06-23T16:44:27.079+09:00  INFO 19789 --- [looper] [nio-8080-exec-7] c.e.l.project.service.ProjectService     : Found 1 projects for user: 1
2025-06-23T16:44:27.079+09:00  INFO 19789 --- [looper] [nio-8080-exec-7] p6spy                                    : #1750664667079 | took 0ms | commit | connection 6| url jdbc:postgresql://localhost:5433/looperdb_main_dev

;
2025-06-23T16:44:27.080+09:00  INFO 19789 --- [looper] [nio-8080-exec-7] i.StatisticalLoggingSessionEventListener : Session Metrics {
    872792 nanoseconds spent acquiring 1 JDBC connections;
    0 nanoseconds spent releasing 0 JDBC connections;
    82208 nanoseconds spent preparing 5 JDBC statements;
    3452458 nanoseconds spent executing 5 JDBC statements;
    0 nanoseconds spent executing 0 JDBC batches;
    0 nanoseconds spent performing 0 L2C puts;
    0 nanoseconds spent performing 0 L2C hits;
    0 nanoseconds spent performing 0 L2C misses;
    0 nanoseconds spent executing 0 flushes (flushing a total of 0 entities and 0 collections);
    3875 nanoseconds spent executing 2 pre-partial-flushes;
    3251 nanoseconds spent executing 2 partial-flushes (flushing a total of 0 entities and 0 collections)
}

```
![image](https://github.com/user-attachments/assets/664eb3f5-1fa4-4527-9c32-4824d31d4821)


이후

```sql
2025-06-23T16:40:08.905+09:00  INFO 19573 --- [looper] [nio-8080-exec-1] c.e.l.project.service.ProjectService     : Getting projects for user: 1
[Hibernate] 
    /* SELECT
        pm 
    FROM
        ProjectMember pm 
    JOIN
        
    FETCH
        pm.project p 
    JOIN
        
    FETCH
        pm.user u 
    WHERE
        u.id = :userId 
        AND pm.deletedAt IS NULL */ select
            pm1_0.id,
            pm1_0.created_at,
            pm1_0.deleted_at,
            pm1_0.position,
            pm1_0.project_id,
            p1_0.id,
            p1_0.color,
            p1_0.created_at,
            p1_0.deleted_at,
            p1_0.member_id,
            p1_0.title,
            p1_0.updated_at,
            p1_0.wiki,
            pm1_0.role,
            pm1_0.updated_at,
            pm1_0.member_id,
            u1_0.id,
            u1_0.created_at,
            u1_0.deleted_at,
            u1_0.email,
            u1_0.file_name,
            u1_0.nickname,
            u1_0.nickname_choseong,
            u1_0.provider,
            u1_0.provider_id,
            u1_0.updated_at 
        from
            project_member pm1_0 
        join
            project p1_0 
                on p1_0.id=pm1_0.project_id 
        join
            member u1_0 
                on u1_0.id=pm1_0.member_id 
        where
            u1_0.id=? 
            and pm1_0.deleted_at is null
2025-06-23T16:40:08.945+09:00  INFO 19573 --- [looper] [nio-8080-exec-1] p6spy                                    : #1750664408945 | took 2ms | statement | connection 3| url jdbc:postgresql://localhost:5433/looperdb_main_dev
/* SELECT pm FROM ProjectMember pm JOIN FETCH pm.project p JOIN FETCH pm.user u WHERE u.id = :userId AND pm.deletedAt IS NULL */ select pm1_0.id,pm1_0.created_at,pm1_0.deleted_at,pm1_0.position,pm1_0.project_id,p1_0.id,p1_0.color,p1_0.created_at,p1_0.deleted_at,p1_0.member_id,p1_0.title,p1_0.updated_at,p1_0.wiki,pm1_0.role,pm1_0.updated_at,pm1_0.member_id,u1_0.id,u1_0.created_at,u1_0.deleted_at,u1_0.email,u1_0.file_name,u1_0.nickname,u1_0.nickname_choseong,u1_0.provider,u1_0.provider_id,u1_0.updated_at from project_member pm1_0 join project p1_0 on p1_0.id=pm1_0.project_id join member u1_0 on u1_0.id=pm1_0.member_id where u1_0.id=? and pm1_0.deleted_at is null
/* SELECT pm FROM ProjectMember pm JOIN FETCH pm.project p JOIN FETCH pm.user u WHERE u.id = :userId AND pm.deletedAt IS NULL */ select pm1_0.id,pm1_0.created_at,pm1_0.deleted_at,pm1_0.position,pm1_0.project_id,p1_0.id,p1_0.color,p1_0.created_at,p1_0.deleted_at,p1_0.member_id,p1_0.title,p1_0.updated_at,p1_0.wiki,pm1_0.role,pm1_0.updated_at,pm1_0.member_id,u1_0.id,u1_0.created_at,u1_0.deleted_at,u1_0.email,u1_0.file_name,u1_0.nickname,u1_0.nickname_choseong,u1_0.provider,u1_0.provider_id,u1_0.updated_at from project_member pm1_0 join project p1_0 on p1_0.id=pm1_0.project_id join member u1_0 on u1_0.id=pm1_0.member_id where u1_0.id=1 and pm1_0.deleted_at is null;
[Hibernate] 
    /* SELECT
        pm 
    FROM
        ProjectMember pm 
    JOIN
        
    FETCH
        pm.user u 
    WHERE
        pm.project.id IN :projectIds 
        AND pm.deletedAt IS NULL */ select
            pm1_0.id,
            pm1_0.created_at,
            pm1_0.deleted_at,
            pm1_0.position,
            pm1_0.project_id,
            pm1_0.role,
            pm1_0.updated_at,
            pm1_0.member_id,
            u1_0.id,
            u1_0.created_at,
            u1_0.deleted_at,
            u1_0.email,
            u1_0.file_name,
            u1_0.nickname,
            u1_0.nickname_choseong,
            u1_0.provider,
            u1_0.provider_id,
            u1_0.updated_at 
        from
            project_member pm1_0 
        join
            member u1_0 
                on u1_0.id=pm1_0.member_id 
        where
            pm1_0.project_id in (?) 
            and pm1_0.deleted_at is null
2025-06-23T16:40:08.962+09:00  INFO 19573 --- [looper] [nio-8080-exec-1] p6spy                                    : #1750664408962 | took 1ms | statement | connection 3| url jdbc:postgresql://localhost:5433/looperdb_main_dev
/* SELECT pm FROM ProjectMember pm JOIN FETCH pm.user u WHERE pm.project.id IN :projectIds AND pm.deletedAt IS NULL */ select pm1_0.id,pm1_0.created_at,pm1_0.deleted_at,pm1_0.position,pm1_0.project_id,pm1_0.role,pm1_0.updated_at,pm1_0.member_id,u1_0.id,u1_0.created_at,u1_0.deleted_at,u1_0.email,u1_0.file_name,u1_0.nickname,u1_0.nickname_choseong,u1_0.provider,u1_0.provider_id,u1_0.updated_at from project_member pm1_0 join member u1_0 on u1_0.id=pm1_0.member_id where pm1_0.project_id in (?) and pm1_0.deleted_at is null
/* SELECT pm FROM ProjectMember pm JOIN FETCH pm.user u WHERE pm.project.id IN :projectIds AND pm.deletedAt IS NULL */ select pm1_0.id,pm1_0.created_at,pm1_0.deleted_at,pm1_0.position,pm1_0.project_id,pm1_0.role,pm1_0.updated_at,pm1_0.member_id,u1_0.id,u1_0.created_at,u1_0.deleted_at,u1_0.email,u1_0.file_name,u1_0.nickname,u1_0.nickname_choseong,u1_0.provider,u1_0.provider_id,u1_0.updated_at from project_member pm1_0 join member u1_0 on u1_0.id=pm1_0.member_id where pm1_0.project_id in (1) and pm1_0.deleted_at is null;
2025-06-23T16:40:08.979+09:00  INFO 19573 --- [looper] [nio-8080-exec-1] c.e.l.project.service.ProjectService     : Found 1 projects for user: 1
2025-06-23T16:40:08.981+09:00  INFO 19573 --- [looper] [nio-8080-exec-1] p6spy                                    : #1750664408981 | took 1ms | commit | connection 3| url jdbc:postgresql://localhost:5433/looperdb_main_dev

;
2025-06-23T16:40:09.001+09:00  INFO 19573 --- [looper] [nio-8080-exec-1] i.StatisticalLoggingSessionEventListener : Session Metrics {
    1101250 nanoseconds spent acquiring 1 JDBC connections;
    0 nanoseconds spent releasing 0 JDBC connections;
    240376 nanoseconds spent preparing 2 JDBC statements;
    3984209 nanoseconds spent executing 2 JDBC statements;
    0 nanoseconds spent executing 0 JDBC batches;
    0 nanoseconds spent performing 0 L2C puts;
    0 nanoseconds spent performing 0 L2C hits;
    0 nanoseconds spent performing 0 L2C misses;
    0 nanoseconds spent executing 0 flushes (flushing a total of 0 entities and 0 collections);
    88208 nanoseconds spent executing 2 pre-partial-flushes;
    6291 nanoseconds spent executing 2 partial-flushes (flushing a total of 0 entities and 0 collections)
}
```
![image](https://github.com/user-attachments/assets/c7090e32-263e-4c6f-84a6-13da14a2306c)

