### PR TITLE
feat: 스케줄 완료율 대시보드

### DIFF
--- a/src/main/java/com/ellu/looper/schedule/controller/AchievementController.java
+++ b/src/main/java/com/ellu/looper/schedule/controller/AchievementController.java
@@ -1,0 +1,46 @@
+package com.ellu.looper.schedule.controller;
+
+import com.ellu.looper.commons.ApiResponse;
+import com.ellu.looper.commons.CurrentUser;
+import com.ellu.looper.schedule.dto.DailyAchievementResponse;
+import com.ellu.looper.schedule.dto.PersonalScheduleAchievementResponse;
+import com.ellu.looper.schedule.dto.PlanAchievementResponse;
+import com.ellu.looper.schedule.service.AchievementService;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/achievements")
+@RequiredArgsConstructor
+public class AchievementController {
+  private final AchievementService achievementService;
+
+  //  지난 한달동안의 하루 단위 일정 생성한 개수 표시(github 잔디밭 ui처럼)
+  @GetMapping("/daily")
+  public ResponseEntity<ApiResponse<List<DailyAchievementResponse>>> dailyAchievement(
+      @CurrentUser Long userId) {
+    List<DailyAchievementResponse> dailyAchievementList =
+        achievementService.getDailyAchievement(userId);
+    return ResponseEntity.ok(new ApiResponse<>("daily_achievements_fetched", dailyAchievementList));
+  }
+
+  //  jira처럼 개인 스케줄 달성률
+  @GetMapping("/user/schedules")
+  public ResponseEntity<?> personalScheduleAchievement(@CurrentUser Long userId) {
+    PersonalScheduleAchievementResponse personalScheduleAchievement =
+        achievementService.getPersonalScheduleAchievement(userId);
+    return ResponseEntity.ok(
+        new ApiResponse<>("personal_schedule_achievement_fetched", personalScheduleAchievement));
+  }
+
+  //  개인 스케줄 중에서 plan별로 달성률(챗봇과 대화해서 스케줄을 생성하면 plan단위로 저장이 됨.)
+  @GetMapping("/plans")
+  public ResponseEntity<?> planAchievement(@CurrentUser Long userId) {
+    List<PlanAchievementResponse> planAchievements = achievementService.getPlanAchievement(userId);
+    return ResponseEntity.ok(new ApiResponse<>("plan_achievements_fetched", planAchievements));
+  }
+}

--- a/src/main/java/com/ellu/looper/schedule/dto/DailyAchievementResponse.java
+++ b/src/main/java/com/ellu/looper/schedule/dto/DailyAchievementResponse.java
@@ -1,0 +1,7 @@
+package com.ellu.looper.schedule.dto;
+
+import java.time.LocalDateTime;
+import lombok.Builder;
+
+@Builder(toBuilder = true)
+public record DailyAchievementResponse(LocalDateTime date, Long numOfCreatedSchedules) {}

--- a/src/main/java/com/ellu/looper/schedule/dto/DailyAchievementResponse.java
+++ b/src/main/java/com/ellu/looper/schedule/dto/DailyAchievementResponse.java
@@ -4,4 +4,4 @@ import java.time.LocalDateTime;
 import lombok.Builder;
 
 @Builder(toBuilder = true)
-public record DailyAchievementResponse(LocalDateTime date, Long numOfCreatedSchedules) {}
+public record DailyAchievementResponse(LocalDateTime date, Long created_schedules) {}

--- a/src/main/java/com/ellu/looper/schedule/dto/PersonalScheduleAchievementResponse.java
+++ b/src/main/java/com/ellu/looper/schedule/dto/PersonalScheduleAchievementResponse.java
@@ -1,4 +1,4 @@
 package com.ellu.looper.schedule.dto;
 
 public record PersonalScheduleAchievementResponse(
-    Long totalSchedules, Long completedSchedules, double achievementRate) {}
+    Long total_schedules, Long completed_schedules, double achievement_rate) {}

--- a/src/main/java/com/ellu/looper/schedule/dto/PersonalScheduleAchievementResponse.java
+++ b/src/main/java/com/ellu/looper/schedule/dto/PersonalScheduleAchievementResponse.java
@@ -1,0 +1,4 @@
+package com.ellu.looper.schedule.dto;
+
+public record PersonalScheduleAchievementResponse(
+    Long totalSchedules, Long completedSchedules, double achievementRate) {}

--- a/src/main/java/com/ellu/looper/schedule/dto/PlanAchievementResponse.java
+++ b/src/main/java/com/ellu/looper/schedule/dto/PlanAchievementResponse.java
@@ -4,4 +4,4 @@ import lombok.Builder;
 
 @Builder
 public record PlanAchievementResponse(
-    String title, Long totalSchedules, Long achievedSchedules, double achievementRate) {}
+    String title, Long total_schedules, Long achieved_schedules, double achievement_rate) {}

--- a/src/main/java/com/ellu/looper/schedule/dto/PlanAchievementResponse.java
+++ b/src/main/java/com/ellu/looper/schedule/dto/PlanAchievementResponse.java
@@ -1,0 +1,7 @@
+package com.ellu.looper.schedule.dto;
+
+import lombok.Builder;
+
+@Builder
+public record PlanAchievementResponse(
+    String title, Long totalSchedules, Long achievedSchedules, double achievementRate) {}

--- a/src/main/java/com/ellu/looper/schedule/entity/Schedule.java
+++ b/src/main/java/com/ellu/looper/schedule/entity/Schedule.java
@@ -79,4 +79,8 @@ public class Schedule {
 
   @Column(name = "deleted_at")
   private LocalDateTime deletedAt;
+
+  public boolean isCompleted() {
+    return this.isCompleted;
+  }
 }

--- a/src/main/java/com/ellu/looper/schedule/entity/Schedule.java
+++ b/src/main/java/com/ellu/looper/schedule/entity/Schedule.java
@@ -26,7 +26,9 @@ import org.hibernate.annotations.UpdateTimestamp;
 @Table(
     indexes = {
       @Index(name = "IDX_SCHEDULE_MEMBER_ID_DELETED_AT", columnList = "member_id, deleted_at"),
-      //      @Index(name = "IDX_SCHEDULE_IS_COMPLETED", columnList = "is_completed")
+      @Index(name = "IDX_SCHEDULE_USER_COMPLETED", columnList = "member_id, is_completed"),
+      @Index(name = "IDX_SCHEDULE_USER_CREATED_AT", columnList = "member_id, created_at")
+      // CREATE INDEX idx_schedule_plan_stats ON schedule(user_id, plan_id, is_completed);
     })
 @Getter
 @NoArgsConstructor

--- a/src/main/java/com/ellu/looper/schedule/repository/PlanRepository.java
+++ b/src/main/java/com/ellu/looper/schedule/repository/PlanRepository.java
@@ -1,6 +1,9 @@
 package com.ellu.looper.schedule.repository;
 
 import com.ellu.looper.schedule.entity.Plan;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface PlanRepository extends JpaRepository<Plan, Long> {}
+public interface PlanRepository extends JpaRepository<Plan, Long> {
+  List<Plan> findByUserId(Long userId);
+}

--- a/src/main/java/com/ellu/looper/schedule/repository/ScheduleRepository.java
+++ b/src/main/java/com/ellu/looper/schedule/repository/ScheduleRepository.java
@@ -36,5 +36,37 @@ public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
 
   Optional<Schedule> findByIdAndUserIdAndDeletedAtIsNull(Long id, Long userId);
 
-  List<Schedule> findByUserIdAndDeletedAtIsNull(Long userId);
+
+  @Query(
+      "SELECT COUNT(s) FROM Schedule s " + "WHERE s.user.id = :userId " + "AND s.deletedAt IS NULL")
+  Long countByUserIdAndDeletedAtIsNull(@Param("userId") Long userId);
+
+  @Query(
+      "SELECT COUNT(s) FROM Schedule s "
+          + "WHERE s.user.id = :userId "
+          + "AND s.deletedAt IS NULL "
+          + "AND s.isCompleted = true")
+  Long countCompletedByUserIdAndDeletedAtIsNull(@Param("userId") Long userId);
+
+  @Query(
+      "SELECT DATE(s.createdAt) as date, COUNT(s) as count "
+          + "FROM Schedule s "
+          + "WHERE s.user.id = :userId "
+          + "AND s.deletedAt IS NULL "
+          + "AND s.createdAt >= :startDate "
+          + "AND s.createdAt < :endDate "
+          + "GROUP BY DATE(s.createdAt)")
+  List<Object[]> countSchedulesByDateRange(
+      @Param("userId") Long userId,
+      @Param("startDate") LocalDateTime startDate,
+      @Param("endDate") LocalDateTime endDate);
+
+  @Query(
+      "SELECT s.plan.id, COUNT(s) as total, COUNT(CASE WHEN s.isCompleted = true THEN 1 END) as completed "
+          + "FROM Schedule s "
+          + "WHERE s.user.id = :userId "
+          + "AND s.deletedAt IS NULL "
+          + "AND s.plan IS NOT NULL "
+          + "GROUP BY s.plan.id")
+  List<Object[]> getPlanAchievementStats(@Param("userId") Long userId);
 }

--- a/src/main/java/com/ellu/looper/schedule/repository/ScheduleRepository.java
+++ b/src/main/java/com/ellu/looper/schedule/repository/ScheduleRepository.java
@@ -35,4 +35,6 @@ public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
       @Param("end") LocalDateTime end);
 
   Optional<Schedule> findByIdAndUserIdAndDeletedAtIsNull(Long id, Long userId);
+
+  List<Schedule> findByUserIdAndDeletedAtIsNull(Long userId);
 }

--- a/src/main/java/com/ellu/looper/schedule/service/AchievementService.java
+++ b/src/main/java/com/ellu/looper/schedule/service/AchievementService.java
@@ -4,14 +4,13 @@ import com.ellu.looper.schedule.dto.DailyAchievementResponse;
 import com.ellu.looper.schedule.dto.PersonalScheduleAchievementResponse;
 import com.ellu.looper.schedule.dto.PlanAchievementResponse;
 import com.ellu.looper.schedule.entity.Plan;
-import com.ellu.looper.schedule.entity.Schedule;
 import com.ellu.looper.schedule.repository.PlanRepository;
 import com.ellu.looper.schedule.repository.ScheduleRepository;
 import java.time.LocalDate;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -28,24 +27,25 @@ public class AchievementService {
     LocalDate endDate = LocalDate.now();
     LocalDate startDate = endDate.minusDays(29);
 
-    List<Schedule> schedules =
-        scheduleRepository.findSchedulesBetween(
-            userId, startDate.atStartOfDay(), endDate.plusDays(1).atStartOfDay().minusNanos(1));
+    List<Object[]> dailyCounts =
+        scheduleRepository.countSchedulesByDateRange(
+            userId, startDate.atStartOfDay(), endDate.plusDays(1).atStartOfDay());
 
-    // 일별로 생성된 일정 개수를 계산
-    Map<LocalDate, Long> dailyCounts =
-        schedules.stream()
-            .collect(
-                Collectors.groupingBy(
-                    schedule -> schedule.getCreatedAt().toLocalDate(), Collectors.counting()));
+    // DB에서 일별 카운트 조회한 결과를 Map으로 변환
+    Map<LocalDate, Long> countMap = new HashMap<>();
+    for (Object[] result : dailyCounts) {
+      LocalDate date = ((java.sql.Date) result[0]).toLocalDate();
+      Long count = ((Number) result[1]).longValue();
+      countMap.put(date, count);
+    }
 
     // 30일간의 모든 날짜에 대해 응답 생성 (0개인 날도 포함)
     for (LocalDate date = startDate; !date.isAfter(endDate); date = date.plusDays(1)) {
-      Long count = dailyCounts.getOrDefault(date, 0L);
+      Long count = countMap.getOrDefault(date, 0L);
       response.add(
           DailyAchievementResponse.builder()
               .date(date.atStartOfDay())
-              .numOfCreatedSchedules(count)
+              .created_schedules(count)
               .build());
     }
 
@@ -54,9 +54,9 @@ public class AchievementService {
 
   // 개인 스케줄 달성률 조회
   public PersonalScheduleAchievementResponse getPersonalScheduleAchievement(Long userId) {
-    List<Schedule> userSchedules = scheduleRepository.findByUserIdAndDeletedAtIsNull(userId);
-    long completedSchedules = userSchedules.stream().filter(Schedule::isCompleted).count();
-    long totalSchedules = userSchedules.size();
+    Long totalSchedules = scheduleRepository.countByUserIdAndDeletedAtIsNull(userId);
+    Long completedSchedules = scheduleRepository.countCompletedByUserIdAndDeletedAtIsNull(userId);
+
     double achievementRate =
         (totalSchedules > 0) ? (double) completedSchedules / totalSchedules * 100.0 : 0.0;
 
@@ -68,31 +68,42 @@ public class AchievementService {
   public List<PlanAchievementResponse> getPlanAchievement(Long userId) {
     List<PlanAchievementResponse> achievementResponses = new ArrayList<>();
     List<Plan> planList = planRepository.findByUserId(userId);
-    List<Schedule> userSchedules = scheduleRepository.findByUserIdAndDeletedAtIsNull(userId);
-    Map<Long, List<Schedule>> schedulesByPlanId =
-        userSchedules.stream()
-            .collect(
-                Collectors.groupingBy(
-                    schedule -> schedule.getPlan() != null ? schedule.getPlan().getId() : null));
+    List<Object[]> planStats = scheduleRepository.getPlanAchievementStats(userId);
+
+    // 결과를 Map으로 변환
+    Map<Long, PlanStats> statsMap = new HashMap<>();
+    for (Object[] result : planStats) {
+      Long planId = (Long) result[0];
+      Long total = ((Number) result[1]).longValue();
+      Long completed = ((Number) result[2]).longValue();
+      statsMap.put(planId, new PlanStats(total, completed));
+    }
 
     for (Plan plan : planList) {
-      List<Schedule> schedulesInPlan =
-          schedulesByPlanId.getOrDefault(plan.getId(), new ArrayList<>());
-      long totalSchedules = schedulesInPlan.size();
-      long achievedSchedules = schedulesInPlan.stream().filter(Schedule::isCompleted).count();
-
+      PlanStats stats = statsMap.getOrDefault(plan.getId(), new PlanStats(0L, 0L));
       double achievementRate =
-          (totalSchedules > 0) ? (double) achievedSchedules / totalSchedules * 100.0 : 0.0;
+          (stats.total > 0) ? (double) stats.completed / stats.total * 100.0 : 0.0;
 
       achievementResponses.add(
           PlanAchievementResponse.builder()
               .title(plan.getTitle())
-              .totalSchedules(totalSchedules)
-              .achievedSchedules(achievedSchedules)
-              .achievementRate(achievementRate)
+              .total_schedules(stats.total)
+              .achieved_schedules(stats.completed)
+              .achievement_rate(achievementRate)
               .build());
     }
 
     return achievementResponses;
+  }
+
+  // Plan 통계 정보
+  private static class PlanStats {
+    final Long total;
+    final Long completed;
+
+    PlanStats(Long total, Long completed) {
+      this.total = total;
+      this.completed = completed;
+    }
   }
 }

--- a/src/main/java/com/ellu/looper/schedule/service/AchievementService.java
+++ b/src/main/java/com/ellu/looper/schedule/service/AchievementService.java
@@ -1,0 +1,98 @@
+package com.ellu.looper.schedule.service;
+
+import com.ellu.looper.schedule.dto.DailyAchievementResponse;
+import com.ellu.looper.schedule.dto.PersonalScheduleAchievementResponse;
+import com.ellu.looper.schedule.dto.PlanAchievementResponse;
+import com.ellu.looper.schedule.entity.Plan;
+import com.ellu.looper.schedule.entity.Schedule;
+import com.ellu.looper.schedule.repository.PlanRepository;
+import com.ellu.looper.schedule.repository.ScheduleRepository;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class AchievementService {
+
+  private final ScheduleRepository scheduleRepository;
+  private final PlanRepository planRepository;
+
+  // 지난 30일간 일 단위로 생성한 일정의 개수 조회
+  public List<DailyAchievementResponse> getDailyAchievement(Long userId) {
+    List<DailyAchievementResponse> response = new ArrayList<>();
+    LocalDate endDate = LocalDate.now();
+    LocalDate startDate = endDate.minusDays(29);
+
+    List<Schedule> schedules =
+        scheduleRepository.findSchedulesBetween(
+            userId, startDate.atStartOfDay(), endDate.plusDays(1).atStartOfDay().minusNanos(1));
+
+    // 일별로 생성된 일정 개수를 계산
+    Map<LocalDate, Long> dailyCounts =
+        schedules.stream()
+            .collect(
+                Collectors.groupingBy(
+                    schedule -> schedule.getCreatedAt().toLocalDate(), Collectors.counting()));
+
+    // 30일간의 모든 날짜에 대해 응답 생성 (0개인 날도 포함)
+    for (LocalDate date = startDate; !date.isAfter(endDate); date = date.plusDays(1)) {
+      Long count = dailyCounts.getOrDefault(date, 0L);
+      response.add(
+          DailyAchievementResponse.builder()
+              .date(date.atStartOfDay())
+              .numOfCreatedSchedules(count)
+              .build());
+    }
+
+    return response;
+  }
+
+  // 개인 스케줄 달성률 조회
+  public PersonalScheduleAchievementResponse getPersonalScheduleAchievement(Long userId) {
+    List<Schedule> userSchedules = scheduleRepository.findByUserIdAndDeletedAtIsNull(userId);
+    long completedSchedules = userSchedules.stream().filter(Schedule::isCompleted).count();
+    long totalSchedules = userSchedules.size();
+    double achievementRate =
+        (totalSchedules > 0) ? (double) completedSchedules / totalSchedules * 100.0 : 0.0;
+
+    return new PersonalScheduleAchievementResponse(
+        totalSchedules, completedSchedules, achievementRate);
+  }
+
+  // 개인 스케줄 중에서 plan별로 달성률 조회
+  public List<PlanAchievementResponse> getPlanAchievement(Long userId) {
+    List<PlanAchievementResponse> achievementResponses = new ArrayList<>();
+    List<Plan> planList = planRepository.findByUserId(userId);
+    List<Schedule> userSchedules = scheduleRepository.findByUserIdAndDeletedAtIsNull(userId);
+    Map<Long, List<Schedule>> schedulesByPlanId =
+        userSchedules.stream()
+            .collect(
+                Collectors.groupingBy(
+                    schedule -> schedule.getPlan() != null ? schedule.getPlan().getId() : null));
+
+    for (Plan plan : planList) {
+      List<Schedule> schedulesInPlan =
+          schedulesByPlanId.getOrDefault(plan.getId(), new ArrayList<>());
+      long totalSchedules = schedulesInPlan.size();
+      long achievedSchedules = schedulesInPlan.stream().filter(Schedule::isCompleted).count();
+
+      double achievementRate =
+          (totalSchedules > 0) ? (double) achievedSchedules / totalSchedules * 100.0 : 0.0;
+
+      achievementResponses.add(
+          PlanAchievementResponse.builder()
+              .title(plan.getTitle())
+              .totalSchedules(totalSchedules)
+              .achievedSchedules(achievedSchedules)
+              .achievementRate(achievementRate)
+              .build());
+    }
+
+    return achievementResponses;
+  }
+}


### PR DESCRIPTION
## ☝️Issue Number
- resolve #169

## 📍 PR 타입 (하나 이상 선택)
- [x] 기능 추가 

## 📌 개요 
-`GET /achievements/daily`: 지난 한달동안의 하루 단위마다 일정 생성한 개수 조회(github 잔디밭 ui처럼)
예시 응답: 
```
{
    "message": "daily_achievements_fetched",
    "data": [
        {
            "date": "2025-06-06T00:00:00",
            "created_schedules": 3
        },
        {
            "date": "2025-06-07T00:00:00",
            "created_schedules": 0
        },
        ...
        {
            "date": "2025-07-05T00:00:00",
            "created_schedules": 1
        }
    ]
}
```
- `GET /achievements/user/schedules`: jira처럼 개인 스케줄 달성률 조회
예시 응답:
```
{
    "message": "personal_schedule_achievement_fetched",
    "data": {
        "total_schedules": 1917,
        "completed_schedules": 3,
        "achievement_rate": 0.1564945226917058
    }
}
```
- `GET /achievements/plans`: 개인 스케줄 중에서 plan별로 달성률 조회(챗봇과 대화해서 스케줄을 생성하면 plan단위로 저장이 됨.)
예시 응답:
```
{
    "message": "plan_achievements_fetched",
    "data": [
        {
            "title": "3일간의 요가 프로그램",
            "total_schedules": 1246,
            "achieved_schedules": 2,
            "achievement_rate": 0.16051364365971107
        },
        {
            "title": "redis 캐싱 공부",
            "total_schedules": 4,
            "achieved_schedules": 0,
            "achievement_rate": 0
        }
    ]
}

```
## ✅ 체크 리스트
- [x] 코드가 정상적으로 컴파일되는지 확인했습니다.
- [x] PR이 관련 이슈를 정확히 참조하고, 적절한 라벨을 선택했습니다.
- [ ] 모든 테스트가 성공적으로 통과했습니다.
- [ ] 관련 문서를 WIKI에 업데이트했습니다.
- [ ] 코드 스타일 가이드라인을 준수했습니다.
- [ ] 코드 리뷰어를 지정했습니다.