### PR TITLE
fix: 채팅 기록 조회를 위한 쿼리 수정

### DIFF
--- a/src/main/java/com/ellu/looper/chat/repository/ChatConversationRepository.java
+++ b/src/main/java/com/ellu/looper/chat/repository/ChatConversationRepository.java
@@ -5,6 +5,6 @@ import java.time.LocalDateTime;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ChatConversationRepository extends JpaRepository<ChatConversation, Long> {
-  ChatConversation findTop1ByUser_IdAndCreatedAtGreaterThanEqualOrderByCreatedAtDesc(
+  ChatConversation findTop1ByUserIdAndUpdatedAtGreaterThanEqualOrderByCreatedAtDesc(
       Long userId, LocalDateTime cutoff);
 }

--- a/src/main/java/com/ellu/looper/chat/service/ChatService.java
+++ b/src/main/java/com/ellu/looper/chat/service/ChatService.java
@@ -42,7 +42,7 @@ public class ChatService {
     log.info("UserId {} fetched chat history. ", userId);
     LocalDateTime cutoff = LocalDateTime.now().minusHours(24);
     ChatConversation recentConversation =
-        conversationRepository.findTop1ByUser_IdAndCreatedAtGreaterThanEqualOrderByCreatedAtDesc(
+        conversationRepository.findTop1ByUserIdAndUpdatedAtGreaterThanEqualOrderByCreatedAtDesc(
             userId, cutoff);
 
     if (recentConversation == null) {


### PR DESCRIPTION
## 개요  

### 🔁 **두 서버 간의 데이터 처리에 차이가 있었음**

1. FastAPI:

   * `chat_conversations` 테이블에서 **`updated_at DESC` 기준으로 가장 최근 것 하나**를 찾음.
   * **24시간 조건 없음.**
   * 없으면 새로 생성하고, 있으면 그걸 계속 사용.
     → 즉, **최근 것이 언제 만들어졌는지와 무관하게 재사용**함.

2. Spring Backend:

   * `chat_conversations` 테이블에서 **`created_at >= 24시간 전`인 가장 최신 대화 1개**만 찾음.
   * 조건에 맞는 게 없으면 **빈 리스트 반환**.

---

### ⚠️ 결과적으로 생기는 문제


* 사용자의 마지막 대화가 3일 전에 있었고, 이후 같은 대화(conversation)에 메시지가 계속 추가되고 있다면…
* Java 서버에서는 **`created_at >= 24시간` 조건**에 걸리지 않아서 **아무 대화도 조회하지 못함**.

그러니 조회가 안 되는 게 당연함

---

### 🔧 해결 방법

**conversation 유효성 판단 기준이 서로 다르기 때문**이므로 

* `created_at` 대신 `updated_at` 기준으로 최근 24시간 내에 활동이 있었던 대화를 찾도록 수정하기로 함:

```java
conversationRepository.findTop1ByUserIdAndUpdatedAtGreaterThanEqualOrderByUpdatedAtDesc(userId, cutoff);
```

FastAPI 서버가 기존 conversation에 메시지를 추가하면서 `updated_at`을 갱신해주고 있으므로 **`updated_at` 기준으로 최근 대화를 찾도록 변경**했음

## ✅ 체크 리스트
- [x] 코드가 정상적으로 컴파일되는지 확인했습니다.
- [x] PR이 관련 이슈를 정확히 참조하고, 적절한 라벨을 선택했습니다.
- [ ] 모든 테스트가 성공적으로 통과했습니다.
- [ ] 관련 문서를 WIKI에 업데이트했습니다.
- [ ] 코드 스타일 가이드라인을 준수했습니다.
- [ ] 코드 리뷰어를 지정했습니다.