### PR TITLE
fix: pod마다 다른 Kafka consumer group.id가 설정되도록 수정

### DIFF
--- a/src/main/java/com/ellu/looper/kafka/ChatConsumer.java
+++ b/src/main/java/com/ellu/looper/kafka/ChatConsumer.java
@@ -20,7 +20,7 @@ public class ChatConsumer {
 
   @KafkaListener(
       topics = "${kafka.topics.chatbot.user-input}",
-      groupId = "${kafka.consumer.group-id}")
+      groupId = "${kafka.consumer.chat-group-id}")
   public void consumeUserMessage(ConsumerRecord<String, String> record) {
     try {
       String key = record.key(); // userId

--- a/src/main/java/com/ellu/looper/kafka/NotificationConsumer.java
+++ b/src/main/java/com/ellu/looper/kafka/NotificationConsumer.java
@@ -99,7 +99,8 @@ public class NotificationConsumer implements Runnable {
   }
 
   public void start() {
-    String groupId = "notification-service-group";
+    // groupId를 각 Pod마다 고유하게 생성
+    String groupId = "notification-service-group-" + java.util.UUID.randomUUID();
 
     // Create consumer properties
     Properties properties = new Properties();

--- a/src/main/java/com/ellu/looper/kafka/ScheduleEventConsumer.java
+++ b/src/main/java/com/ellu/looper/kafka/ScheduleEventConsumer.java
@@ -43,6 +43,9 @@ public class ScheduleEventConsumer implements Runnable {
   @Value("${kafka.topics.schedule}")
   public String SCHEDULE_TOPIC;
 
+  @Value("${info.pod.name}")
+  private String podName;
+
   @PostConstruct
   public void init() {
     log.info("ScheduleEventConsumer init() called");
@@ -50,7 +53,8 @@ public class ScheduleEventConsumer implements Runnable {
   }
 
   public void start() {
-    String groupId = "schedule-service-group";
+    // groupId를 각 Pod마다 고유하게 생성
+    String groupId = "schedule-service-group-" + podName;
 
     Properties properties = new Properties();
     properties.setProperty("bootstrap.servers", bootstrapServers);

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -114,8 +114,8 @@ kafka:
     preview:
       preview-result
   consumer:
-    group-id: chat-group
-    preview-group-id: preview-consumer-group
+    chat-group-id: chat-consumer-${info.pod.name}
+    preview-group-id: preview-consumer-${info.pod.name}
 
 cache:
   project:
@@ -131,3 +131,5 @@ info:
     name: ${spring.application.name}
     version: 1.0.1
     description: Looper API 서버
+  pod:
+    name: ${HOSTNAME}


### PR DESCRIPTION
## 환경 변수 추가됨 
`HOSTNAME`<- Kubernetes Pod의 환경 변수에서 HOSTNAME을 가져와서 설정(Pod의 고유 식별자(예: Pod 이름, 호스트명, UUID 등)로 설정)
## ☝️Issue Number
- resolve #180 

## 📍 PR 타입 (하나 이상 선택)
- [x] 버그 수정


## 🔎 Key Changes

* **NotificationConsumer**: `src/main/java/com/ellu/looper/kafka/NotificationConsumer.java`
    * Kafka Consumer의 `group.id`를 `"notification-service-group-<podName>"`으로 Pod별 고유하게 설정.
* **ChatConsumer**: `src/main/java/com/ellu/looper/kafka/ChatConsumer.java`
    * `application.yml`에서 `group-id`를 `"chat-consumer-${info.pod.name}"`로 Pod별 고유하게 설정.
* **ScheduleEventConsumer**: `src/main/java/com/ellu/looper/kafka/ScheduleEventConsumer.java`
    * Kafka Consumer의 `group.id`를 `"schedule-service-group-<podName>"`으로 Pod별 고유하게 설정.
* **PreviewResultConsumer**: `src/main/java/com/ellu/looper/kafka/PreviewResultConsumer.java`
    * `application.yml`에서 `group-id`를 `"preview-consumer-${info.pod.name}"`로 Pod별 고유하게 설정.
* **application.yml**: `src/main/resources/application.yml`
    * 각 Consumer별 `group-id`를 Pod별 고유하게 설정하도록 변경.


## ✅ 체크 리스트
- [x] 코드가 정상적으로 컴파일되는지 확인했습니다.
- [x] PR이 관련 이슈를 정확히 참조하고, 적절한 라벨을 선택했습니다.
- [ ] 모든 테스트가 성공적으로 통과했습니다.
- [ ] 관련 문서를 WIKI에 업데이트했습니다.
- [ ] 코드 스타일 가이드라인을 준수했습니다.
- [ ] 코드 리뷰어를 지정했습니다.