### PR TITLE
fix: redis에 session 정보 저장

### DIFF
--- a/src/main/java/com/ellu/looper/config/SecurityConfig.java
+++ b/src/main/java/com/ellu/looper/config/SecurityConfig.java
@@ -60,7 +60,7 @@ public class SecurityConfig {
     CorsConfiguration configuration = new CorsConfiguration();
     configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
     configuration.setAllowedOriginPatterns(
-        List.of("http://localhost:3000", "https://looper.my", "https://dev.looper.my"));
+        List.of("http://localhost:3000", "http://localhost:3001", "https://looper.my", "https://dev.looper.my"));
     configuration.setAllowedHeaders(List.of("*"));
     configuration.setAllowCredentials(true); // 쿠키 인증 허용
     configuration.setMaxAge(3600L); // 1시간

--- a/src/main/java/com/ellu/looper/config/SecurityConfig.java
+++ b/src/main/java/com/ellu/looper/config/SecurityConfig.java
@@ -60,7 +60,7 @@ public class SecurityConfig {
     CorsConfiguration configuration = new CorsConfiguration();
     configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
     configuration.setAllowedOriginPatterns(
-        List.of("http://localhost:3000", "http://localhost:3001", "https://looper.my", "https://dev.looper.my"));
+        List.of("http://localhost:3000", "https://looper.my", "https://dev.looper.my"));
     configuration.setAllowedHeaders(List.of("*"));
     configuration.setAllowCredentials(true); // 쿠키 인증 허용
     configuration.setMaxAge(3600L); // 1시간

--- a/src/main/java/com/ellu/looper/config/StompWebsocketConfig.java
+++ b/src/main/java/com/ellu/looper/config/StompWebsocketConfig.java
@@ -23,7 +23,7 @@ public class StompWebsocketConfig implements WebSocketMessageBrokerConfigurer {
     registry
         .addEndpoint("/connect")
         .setAllowedOrigins(
-            "http://localhost:3000","http://localhost:3001",
+            "http://localhost:3000",
             "https://looper.my",
             "https://dev.looper.my") // websocket관련 cors설정
         .withSockJS(); // ws://가 아닌 http:// endpoint를 사용할 수 있게 해주는 sockJs library를 통한 요청 허용

--- a/src/main/java/com/ellu/looper/config/StompWebsocketConfig.java
+++ b/src/main/java/com/ellu/looper/config/StompWebsocketConfig.java
@@ -23,7 +23,7 @@ public class StompWebsocketConfig implements WebSocketMessageBrokerConfigurer {
     registry
         .addEndpoint("/connect")
         .setAllowedOrigins(
-            "http://localhost:3000",
+            "http://localhost:3000","http://localhost:3001",
             "https://looper.my",
             "https://dev.looper.my") // websocket관련 cors설정
         .withSockJS(); // ws://가 아닌 http:// endpoint를 사용할 수 있게 해주는 sockJs library를 통한 요청 허용

--- a/src/main/java/com/ellu/looper/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/ellu/looper/jwt/JwtAuthenticationFilter.java
@@ -6,6 +6,7 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpSession;
 import java.io.IOException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpHeaders;
@@ -48,6 +49,12 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         JwtAuthenticationToken authentication = new JwtAuthenticationToken(userId);
         authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
         SecurityContextHolder.getContext().setAuthentication(authentication);
+
+        if (userId != null) {
+            // 세션에 userId 저장 (SSE 등에서 사용)
+            HttpSession session = request.getSession(true); // 없으면 생성
+            session.setAttribute("userId", userId);
+        }
 
       } catch (JwtException e) {
         if ("Token expired".equals(e.getMessage())) {

--- a/src/main/java/com/ellu/looper/kafka/NotificationConsumer.java
+++ b/src/main/java/com/ellu/looper/kafka/NotificationConsumer.java
@@ -23,7 +23,7 @@ import com.ellu.looper.schedule.entity.Assignee;
 import com.ellu.looper.schedule.entity.ProjectSchedule;
 import com.ellu.looper.schedule.repository.AssigneeRepository;
 import com.ellu.looper.schedule.repository.ProjectScheduleRepository;
-import com.ellu.looper.sse.service.SseService;
+import com.ellu.looper.sse.service.NotificationSseService;
 import com.ellu.looper.user.entity.User;
 import com.ellu.looper.user.repository.UserRepository;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -54,7 +54,7 @@ public class NotificationConsumer implements Runnable {
   private static final Logger log =
       LoggerFactory.getLogger(NotificationConsumer.class.getSimpleName());
   private final ObjectMapper objectMapper;
-  private final SseService sseEmitterService;
+  private final NotificationSseService notificationSseService;
   private KafkaConsumer<String, String> consumer;
   private volatile boolean running = true;
 
@@ -337,7 +337,7 @@ public class NotificationConsumer implements Runnable {
       }
 
       // SSE 구독 중인 유저에게 전송
-      sseEmitterService.sendNotification(
+      notificationSseService.sendNotificationToUser(
           userId, event.toBuilder().notificationId(saved.getId()).build());
     }
   }

--- a/src/main/java/com/ellu/looper/kafka/ScheduleEventConsumer.java
+++ b/src/main/java/com/ellu/looper/kafka/ScheduleEventConsumer.java
@@ -5,6 +5,7 @@ import com.ellu.looper.schedule.dto.ProjectScheduleResponse;
 import com.ellu.looper.schedule.entity.ProjectSchedule;
 import com.ellu.looper.schedule.repository.ProjectScheduleRepository;
 import com.ellu.looper.schedule.service.ProjectScheduleService;
+import com.ellu.looper.stomp.service.StompSessionRoutingService;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.annotation.PostConstruct;
 import jakarta.persistence.EntityNotFoundException;
@@ -12,6 +13,7 @@ import java.time.Duration;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Properties;
+import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
@@ -21,7 +23,6 @@ import org.apache.kafka.common.serialization.StringDeserializer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Service;
 
 @RequiredArgsConstructor
@@ -30,12 +31,12 @@ public class ScheduleEventConsumer implements Runnable {
   private static final Logger log =
       LoggerFactory.getLogger(ScheduleEventConsumer.class.getSimpleName());
   private final ObjectMapper objectMapper;
-  private final SimpMessagingTemplate messagingTemplate;
   private KafkaConsumer<String, String> consumer;
   private volatile boolean running = true;
 
   private final ProjectScheduleService projectScheduleService;
   private final ProjectScheduleRepository projectScheduleRepository;
+  private final StompSessionRoutingService stompSessionRoutingService;
 
   @Value("${spring.kafka.bootstrap-servers}")
   private String bootstrapServers;
@@ -115,6 +116,12 @@ public class ScheduleEventConsumer implements Runnable {
   }
 
   private void processScheduleEvent(ScheduleEventMessage event) {
+    log.info("Processing schedule event: type={}, projectId={}, userId={}, scheduleId={}", 
+        event.getType(), event.getProjectId(), event.getUserId(), event.getScheduleId());
+    
+    // 실제 프로젝트에 접속 중인 세션
+    Long projectId = Long.valueOf(event.getProjectId());
+    Set<String> activeSessionIds = stompSessionRoutingService.getProjectSessionIds(projectId);
     switch (event.getType()) {
       case "SCHEDULE_CREATED":
         List<ProjectScheduleResponse> createdList =
@@ -122,7 +129,11 @@ public class ScheduleEventConsumer implements Runnable {
                 Long.valueOf(event.getProjectId()), event.getUserId(), event.getCreateRequest());
         for (ProjectScheduleResponse response : createdList) {
           event = event.toBuilder().schedule(projectScheduleService.toDto(response)).build();
-          messagingTemplate.convertAndSend("/topic/" + event.getProjectId(), event);
+          // WebSocket 브로드캐스트 (실제 접속 중인 세션에만)
+          for (String sessionId : activeSessionIds) {
+            stompSessionRoutingService.sendMessageToUser(sessionId, "/create",
+                event, event.getProjectId());
+          }
         }
         break;
 
@@ -134,10 +145,11 @@ public class ScheduleEventConsumer implements Runnable {
             event.toBuilder()
                 .schedule(projectScheduleService.toDto(projectScheduleResponse))
                 .build();
-
-        // WebSocket 브로드캐스트
-        messagingTemplate.convertAndSend("/topic/" + event.getProjectId(), event);
-
+        // WebSocket 브로드캐스트 (실제 접속 중인 세션에만)
+        for (String sessionId : activeSessionIds) {
+          stompSessionRoutingService.sendMessageToUser(sessionId, "/update", event,
+              event.getProjectId());
+        }
         break;
 
       case "SCHEDULE_TAKEN":
@@ -155,18 +167,20 @@ public class ScheduleEventConsumer implements Runnable {
                     projectScheduleService.toDto(
                         projectScheduleService.toResponse(updatedSchedule)))
                 .build();
-
-        // WebSocket 브로드캐스트
-        messagingTemplate.convertAndSend("/topic/" + event.getProjectId(), event);
-
+        // WebSocket 브로드캐스트 (실제 접속 중인 세션에만)
+        for (String sessionId : activeSessionIds) {
+          stompSessionRoutingService.sendMessageToUser(sessionId, "/take",event,
+              event.getProjectId());
+        }
         break;
 
       case "SCHEDULE_DELETED":
         projectScheduleService.deleteSchedule(event.getScheduleId(), event.getUserId());
-
-        // WebSocket 브로드캐스트
-        messagingTemplate.convertAndSend("/topic/" + event.getProjectId(), event);
-
+        // WebSocket 브로드캐스트 (실제 접속 중인 세션에만)
+        for (String sessionId : activeSessionIds) {
+          stompSessionRoutingService.sendMessageToUser(sessionId, "/delete", event,
+              event.getProjectId());
+        }
         break;
     }
   }

--- a/src/main/java/com/ellu/looper/kafka/config/KafkaStreamsConfig.java
+++ b/src/main/java/com/ellu/looper/kafka/config/KafkaStreamsConfig.java
@@ -2,7 +2,7 @@ package com.ellu.looper.kafka.config;
 
 import static org.apache.kafka.streams.StreamsConfig.*;
 
-import com.ellu.looper.sse.service.SseEmitterService;
+import com.ellu.looper.sse.service.ChatSseService;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -48,7 +48,7 @@ public class KafkaStreamsConfig {
 
   @Bean
   public KStream<String, String> chatResponseStream(
-      StreamsBuilder streamsBuilder, SseEmitterService sseEmitterService) {
+      StreamsBuilder streamsBuilder, ChatSseService chatSseService) {
     KStream<String, String> stream =
         streamsBuilder.stream(responseTopic, Consumed.with(Serdes.String(), Serdes.String()));
 
@@ -82,7 +82,7 @@ public class KafkaStreamsConfig {
               String text = dataNode.get("text").asText();
               boolean done = dataNode.get("done").asBoolean();
 
-              sseEmitterService.sendMessage(key, text, done);
+              chatSseService.sendMessageToUser(Long.valueOf(key), text, done);
 
             } else if (messageNode.asText().equals("task_response")) { // 스케줄 데이터가 포함된 메시지
               JsonNode taskTitleNode = dataNode.get("task_title");
@@ -109,14 +109,14 @@ public class KafkaStreamsConfig {
                 endTime = detailNode.get("end_time").asText();
               }
 
-              sseEmitterService.sendSchedulePreview(
+              chatSseService.sendSchedulePreview(
                   key, planTitle, category, subtaskTitle, startTime, endTime, done);
 
             } else { // 일반적인 대화 메시지
               String token = dataNode.get("token").asText();
               boolean done = dataNode.get("done").asBoolean();
 
-              sseEmitterService.sendMessage(key, token, done);
+              chatSseService.sendMessageToUser(Long.valueOf(key), token, done);
             }
 
           } catch (JsonProcessingException e) {

--- a/src/main/java/com/ellu/looper/kafka/service/ChatStreamService.java
+++ b/src/main/java/com/ellu/looper/kafka/service/ChatStreamService.java
@@ -1,6 +1,6 @@
 package com.ellu.looper.kafka.service;
 
-import com.ellu.looper.sse.service.SseEmitterService;
+import com.ellu.looper.sse.service.ChatSseService;
 import java.util.function.Consumer;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -12,7 +12,7 @@ import org.springframework.stereotype.Service;
 @Service
 @RequiredArgsConstructor
 public class ChatStreamService {
-  private final SseEmitterService sseEmitterService;
+  private final ChatSseService chatSseService;
 
   @Bean
   public Consumer<KStream<String, String>> processChatResponse() {
@@ -20,7 +20,7 @@ public class ChatStreamService {
         stream.foreach(
             (userId, token) -> {
               log.debug("Processing response for user {}: {}", userId, token);
-              sseEmitterService.sendToken(userId, token, false);
+              chatSseService.sendTokenToUser(userId, token, false);
             });
   }
 }

--- a/src/main/java/com/ellu/looper/sse/controller/SseController.java
+++ b/src/main/java/com/ellu/looper/sse/controller/SseController.java
@@ -1,8 +1,9 @@
 package com.ellu.looper.sse.controller;
 
 import com.ellu.looper.commons.CurrentUser;
-import com.ellu.looper.sse.service.SseEmitterService;
-import com.ellu.looper.sse.service.SseService;
+import com.ellu.looper.sse.service.ChatSseService;
+import com.ellu.looper.sse.service.NotificationSseService;
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -15,16 +16,16 @@ import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 @RequestMapping("/sse")
 public class SseController {
 
-  private final SseService sseService;
-  private final SseEmitterService sseEmitterService;
+  private final ChatSseService chatSseService;
+  private final NotificationSseService notificationSseService;
 
   @GetMapping(value = "/subscribe", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
-  public SseEmitter subscribe(@CurrentUser Long userId) {
-    return sseService.subscribe(userId);
+  public SseEmitter subscribe(@CurrentUser Long userId, HttpServletRequest request) {
+    return notificationSseService.subscribe(request, userId);
   }
 
   @GetMapping(value = "/chat/stream", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
-  public SseEmitter streamChat(@CurrentUser Long userId) {
-    return sseEmitterService.createEmitter(userId.toString());
+  public SseEmitter streamChat(@CurrentUser Long userId, HttpServletRequest request) {
+    return chatSseService.createEmitter(request, userId);
   }
 }

--- a/src/main/java/com/ellu/looper/sse/dto/SsePubSubMessage.java
+++ b/src/main/java/com/ellu/looper/sse/dto/SsePubSubMessage.java
@@ -1,0 +1,16 @@
+package com.ellu.looper.sse.dto;
+
+import com.ellu.looper.kafka.dto.NotificationMessage;
+import java.io.Serializable;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class SsePubSubMessage implements Serializable {
+    private String targetSessionId;
+    private String eventName;
+    private String data;
+} 

--- a/src/main/java/com/ellu/looper/sse/dto/SsePubSubMessage.java
+++ b/src/main/java/com/ellu/looper/sse/dto/SsePubSubMessage.java
@@ -1,6 +1,5 @@
 package com.ellu.looper.sse.dto;
 
-import com.ellu.looper.kafka.dto.NotificationMessage;
 import java.io.Serializable;
 import lombok.AllArgsConstructor;
 import lombok.Data;

--- a/src/main/java/com/ellu/looper/sse/service/ChatSseService.java
+++ b/src/main/java/com/ellu/looper/sse/service/ChatSseService.java
@@ -1,74 +1,185 @@
 package com.ellu.looper.sse.service;
 
+import com.ellu.looper.sse.dto.SsePubSubMessage;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.io.IOException;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.data.redis.core.RedisTemplate;
+import java.util.concurrent.TimeUnit;
 
 @Slf4j
 @Service
+@RequiredArgsConstructor
 public class ChatSseService {
+
   private final Map<String, SseEmitter> emitters = new ConcurrentHashMap<>();
   private final ObjectMapper objectMapper = new ObjectMapper();
+  private final RedisTemplate<String, Object> redisTemplate;
+  private static final String routingKeyPrefix = "sse:routing:chat:";
+  private static final String SSE_CHANNEL = "sse:events";
 
-  public SseEmitter createEmitter(String userId) {
+
+  public SseEmitter createEmitter(HttpServletRequest request, Long userId) {
+    String sessionId = request.getSession().getId();
     SseEmitter emitter = new SseEmitter(Long.MAX_VALUE);
-    log.info("UserId {} is connected to sse. ", userId);
+    emitters.put(sessionId, emitter);
+    log.info("SessionId {} is connected to chat stream.", sessionId);
 
     emitter.onCompletion(
         () -> {
-          log.info("SSE completed for user: {}", userId);
-          emitters.remove(userId);
+          log.info("SSE completed for session: {}", sessionId);
+          emitters.remove(sessionId);
+          unregisterSession(userId);
         });
 
     emitter.onTimeout(
         () -> {
-          log.info("SSE timeout for user: {}", userId);
-          emitters.remove(userId);
+          emitters.remove(sessionId);
+          unregisterSession(userId);
+          log.info("SSE timeout for session: {}", sessionId);
         });
 
     emitter.onError(
         e -> {
-          log.error("SSE error for user: {}", userId, e);
-          emitters.remove(userId);
+          log.error("SSE error for session: {}", sessionId, e);
+          emitters.remove(sessionId);
+          unregisterSession(userId);
         });
-
-    emitters.put(userId, emitter);
+    registerSession(userId, sessionId);
     return emitter;
   }
 
-  public void sendToken(String userId, String token, boolean done) {
-    SseEmitter emitter = emitters.get(userId);
-    if (emitter != null) {
-      try {
-        emitter.send(
-            SseEmitter.event()
-                .name("token")
-                .data("{\"token\":\"" + token + "\",\"done\":" + done + "}"));
-      } catch (IOException e) {
-        log.error("Error sending SSE to user: {}", userId, e);
-        emitters.remove(userId);
+  public void registerSession(Long userId, String sessionId) {
+    String key = routingKeyPrefix + userId;
+    redisTemplate.opsForValue().set(key, sessionId, 1, TimeUnit.HOURS); // 1시간 라우팅 타임아웃
+    log.info("Registered session {} to routing.", userId);
+  }
+
+  public void unregisterSession(Long userId) {
+    String key = routingKeyPrefix + userId;
+    redisTemplate.delete(key);
+    log.info("Unregistered session {} from routing.", userId);
+  }
+
+  public SseEmitter getEmitter(String sessionId) {
+    return emitters.get(sessionId);
+  }
+
+  public void removeEmitter(String sessionId) {
+    emitters.remove(sessionId);
+  }
+
+  public void sendToLocalSession(String sessionId, String eventName, String data) {
+    try {
+      SseEmitter emitter = getEmitter(sessionId);
+      if (emitter != null) {
+        emitter.send(SseEmitter.event().name(eventName).data(data));
+        log.debug("Sent message to local session {}: {} - {}", sessionId, eventName, data);
+        return;
       }
+      log.warn("No emitter found for local session {}", sessionId);
+      throw new IllegalStateException("No emitter found for local session " + sessionId);
+    } catch (Exception e) {
+      log.error("Error sending message to local session {}", sessionId, e);
     }
   }
 
-  public void sendMessage(String userId, String message, boolean done) {
-    SseEmitter emitter = emitters.get(userId);
-    if (emitter != null) {
-      try {
-        emitter.send(
-            SseEmitter.event()
-                .name("message")
-                .data("{\"message\":\"" + message + "\",\"done\":" + done + "}"));
-      } catch (IOException e) {
-        log.error("Error sending SSE to user: {}", userId, e);
-        emitters.remove(userId);
+  private String getTargetSession(Long userId) {
+    String key = routingKeyPrefix + userId;
+    Object value = redisTemplate.opsForValue().get(key);
+    if (value instanceof String) {
+      return (String) value;
+    }
+    return null;
+  }
+
+  private boolean isCurrentSession(Long userId, String sessionId) {
+    return sessionId.equals(redisTemplate.opsForValue().get(routingKeyPrefix + userId));
+  }
+
+  private void forwardToSession(String targetSessionId, String eventName, String data) {
+    try {
+      // Redis Pub/Sub을 통해 메시지 전달
+      SsePubSubMessage message = new SsePubSubMessage(targetSessionId, eventName, data);
+      redisTemplate.convertAndSend(SSE_CHANNEL, message);
+      log.info("Published SSE message to channel {} for session {}", SSE_CHANNEL, targetSessionId);
+    } catch (Exception e) {
+      log.error("Error publishing SSE message to channel {}: {}", SSE_CHANNEL, e.getMessage());
+    }
+  }
+
+  // userId로부터 sessionId를 조회해 메시지 전송
+  public void sendTokenToUser(String userId, String token, boolean done) {
+    String sessionId = (String) redisTemplate.opsForValue().get(routingKeyPrefix + userId);
+    if (sessionId != null) {
+      sendToken(Long.valueOf(userId), sessionId, token, done);
+    } else {
+      log.warn("No sessionId found for userId {} when trying to send message", userId);
+    }
+  }
+
+
+  public void sendToken(Long userId, String sessionId, String token, boolean done) {
+    try {
+      String targetSessionId = getTargetSession(userId);
+      if (targetSessionId == null) {
+        log.warn("No routing information found for session {}", sessionId);
+        return;
       }
+      if (isCurrentSession(userId, targetSessionId)) {
+
+        SseEmitter localEmitter = getEmitter(sessionId);
+        if (localEmitter != null) {
+          sendToLocalSession(sessionId,"token", "{\"token\":\"" + token + "\",\"done\":" + done + "}");
+        }
+      } else {
+        forwardToSession(targetSessionId, "token","{\"token\":\"" + token + "\",\"done\":" + done + "}");
+      }
+    } catch (Exception e) {
+      log.error("Error sending message to session {}: {}", sessionId, e.getMessage());
+      removeEmitter(sessionId);
+      unregisterSession(userId);
+    }
+  }
+
+  // userId로부터 sessionId를 조회해 메시지 전송
+  public void sendMessageToUser(Long userId, String message, boolean done) {
+    String sessionId = (String) redisTemplate.opsForValue().get(routingKeyPrefix + userId);
+    if (sessionId != null) {
+      sendMessage(userId, sessionId, message, done);
+    } else {
+      log.warn("No sessionId found for userId {} when trying to send message", userId);
+    }
+  }
+
+  public void sendMessage(Long userId, String sessionId, String message, boolean done) {
+    try {
+      String targetSessionId = getTargetSession(userId);
+      if (targetSessionId == null) {
+        log.warn("No routing information found for session {}", sessionId);
+        return;
+      }
+      if (isCurrentSession(userId, targetSessionId)) {
+
+        SseEmitter localEmitter = getEmitter(sessionId);
+        if (localEmitter != null) {
+          sendToLocalSession(sessionId,"message", "{\"message\":\"" + message + "\",\"done\":" + done + "}");
+        }
+      } else {
+        forwardToSession(targetSessionId, "message","{\"message\":\"" + message + "\",\"done\":" + done + "}");
+      }
+    } catch (Exception e) {
+      log.error("Error sending message to session {}: {}", sessionId, e.getMessage());
+      removeEmitter(sessionId);
+      unregisterSession(userId);
     }
   }
 

--- a/src/main/java/com/ellu/looper/sse/service/ChatSseService.java
+++ b/src/main/java/com/ellu/looper/sse/service/ChatSseService.java
@@ -12,7 +12,7 @@ import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 @Slf4j
 @Service
-public class SseEmitterService {
+public class ChatSseService {
   private final Map<String, SseEmitter> emitters = new ConcurrentHashMap<>();
   private final ObjectMapper objectMapper = new ObjectMapper();
 

--- a/src/main/java/com/ellu/looper/sse/service/ChatSseService.java
+++ b/src/main/java/com/ellu/looper/sse/service/ChatSseService.java
@@ -102,7 +102,8 @@ public class ChatSseService {
   }
 
   private boolean isCurrentSession(Long userId, String sessionId) {
-    return sessionId.equals(redisTemplate.opsForValue().get(routingKeyPrefix + userId));
+    Object redisSession = redisTemplate.opsForValue().get(routingKeyPrefix + userId);
+    return sessionId.equals(redisSession) && emitters.containsKey(sessionId);
   }
 
   private void forwardToSession(String targetSessionId, String eventName, String data) {
@@ -134,7 +135,7 @@ public class ChatSseService {
         log.warn("No routing information found for session {}", sessionId);
         return;
       }
-      if (isCurrentSession(userId, targetSessionId)) {
+      if (isCurrentSession(userId, sessionId)) {
 
         SseEmitter localEmitter = getEmitter(sessionId);
         if (localEmitter != null) {

--- a/src/main/java/com/ellu/looper/sse/service/NotificationSseService.java
+++ b/src/main/java/com/ellu/looper/sse/service/NotificationSseService.java
@@ -12,7 +12,7 @@ import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 @Service
 @Slf4j
-public class SseService {
+public class NotificationSseService {
 
   private final Map<Long, SseEmitter> emitters = new ConcurrentHashMap<>();
 
@@ -51,19 +51,5 @@ public class SseService {
     } else {
       log.info("No active emitter for user {}", userId);
     }
-  }
-
-  private NotificationResponse notificationToDto(Notification notification) {
-    return NotificationResponse.builder()
-        .id(notification.getId())
-        .message(renderTemplate(notification.getTemplate().getTemplate(), notification))
-        .build();
-  }
-
-  private String renderTemplate(String template, Notification notification) {
-    // 실제 초대 메시지로 변환: "{{creator}}님이 {{project}}에 초대했습니다."
-    return template
-        .replace("{{creator}}", notification.getSender().getNickname())
-        .replace("{{project}}", notification.getProject().getTitle());
   }
 }

--- a/src/main/java/com/ellu/looper/sse/service/NotificationSseService.java
+++ b/src/main/java/com/ellu/looper/sse/service/NotificationSseService.java
@@ -5,7 +5,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.http.HttpServletRequest;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.TimeUnit;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -101,8 +100,8 @@ public class NotificationSseService {
   }
 
   private boolean isCurrentSession(Long userId, String sessionId) {
-    log.info("sessionId :{}, in redis: {}",sessionId, redisTemplate.opsForValue().get(routingKeyPrefix + userId));
-    return sessionId.equals(redisTemplate.opsForValue().get(routingKeyPrefix + userId));
+    Object redisSession = redisTemplate.opsForValue().get(routingKeyPrefix + userId);
+    return sessionId.equals(redisSession) && emitters.containsKey(sessionId);
   }
 
   private void forwardToSession(String targetSessionId, String eventName,

--- a/src/main/java/com/ellu/looper/sse/service/SsePubSubConfig.java
+++ b/src/main/java/com/ellu/looper/sse/service/SsePubSubConfig.java
@@ -1,0 +1,23 @@
+package com.ellu.looper.sse.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.listener.ChannelTopic;
+import org.springframework.data.redis.listener.RedisMessageListenerContainer;
+
+@Configuration
+@RequiredArgsConstructor
+public class SsePubSubConfig {
+    private final RedisConnectionFactory redisConnectionFactory;
+    private final SsePubSubListener ssePubSubListener;
+
+    @Bean
+    public RedisMessageListenerContainer redisMessageListenerContainer() {
+        RedisMessageListenerContainer container = new RedisMessageListenerContainer();
+        container.setConnectionFactory(redisConnectionFactory);
+        container.addMessageListener(ssePubSubListener, new ChannelTopic("sse:events"));
+        return container;
+    }
+} 

--- a/src/main/java/com/ellu/looper/sse/service/SsePubSubListener.java
+++ b/src/main/java/com/ellu/looper/sse/service/SsePubSubListener.java
@@ -5,7 +5,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.connection.Message;
 import org.springframework.data.redis.connection.MessageListener;
-import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
 import org.springframework.stereotype.Component;
 
 @Slf4j
@@ -14,12 +14,12 @@ import org.springframework.stereotype.Component;
 public class SsePubSubListener implements MessageListener {
     private final ChatSseService chatSseService;
     private final NotificationSseService notificationSseService;
-    private final Jackson2JsonRedisSerializer<SsePubSubMessage> serializer = new Jackson2JsonRedisSerializer<>(SsePubSubMessage.class);
+    private final GenericJackson2JsonRedisSerializer serializer = new GenericJackson2JsonRedisSerializer(); // SsePubSubMessage.class 지정 불필요
 
     @Override
     public void onMessage(Message message, byte[] pattern) {
         try {
-            SsePubSubMessage pubSubMessage = serializer.deserialize(message.getBody());
+            SsePubSubMessage pubSubMessage = (SsePubSubMessage) serializer.deserialize(message.getBody());
             if (pubSubMessage == null) return;
             String sessionId = pubSubMessage.getTargetSessionId();
             if (chatSseService.getEmitter(sessionId) != null) {

--- a/src/main/java/com/ellu/looper/sse/service/SsePubSubListener.java
+++ b/src/main/java/com/ellu/looper/sse/service/SsePubSubListener.java
@@ -1,0 +1,37 @@
+package com.ellu.looper.sse.service;
+
+import com.ellu.looper.sse.dto.SsePubSubMessage;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.connection.Message;
+import org.springframework.data.redis.connection.MessageListener;
+import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class SsePubSubListener implements MessageListener {
+    private final ChatSseService chatSseService;
+    private final NotificationSseService notificationSseService;
+    private final Jackson2JsonRedisSerializer<SsePubSubMessage> serializer = new Jackson2JsonRedisSerializer<>(SsePubSubMessage.class);
+
+    @Override
+    public void onMessage(Message message, byte[] pattern) {
+        try {
+            SsePubSubMessage pubSubMessage = serializer.deserialize(message.getBody());
+            if (pubSubMessage == null) return;
+            String sessionId = pubSubMessage.getTargetSessionId();
+            if (chatSseService.getEmitter(sessionId) != null) {
+                chatSseService.sendToLocalSession(sessionId, pubSubMessage.getEventName(), pubSubMessage.getData());
+                log.info("Delivered chat SSE message to local session {} via PubSub", sessionId);
+            }
+            if (notificationSseService.getEmitter(sessionId) != null) {
+                notificationSseService.sendToLocalSession(sessionId, pubSubMessage.getEventName(), pubSubMessage.getData());
+                log.info("Delivered notification SSE message to local session {} via PubSub", sessionId);
+            }
+        } catch (Exception e) {
+            log.error("Failed to process SSE PubSub message", e);
+        }
+    }
+} 

--- a/src/main/java/com/ellu/looper/stomp/StompEventListener.java
+++ b/src/main/java/com/ellu/looper/stomp/StompEventListener.java
@@ -8,6 +8,10 @@ import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
 import org.springframework.stereotype.Component;
 import org.springframework.web.socket.messaging.SessionConnectEvent;
 import org.springframework.web.socket.messaging.SessionDisconnectEvent;
+import com.ellu.looper.stomp.service.StompSessionRoutingService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.socket.messaging.SessionSubscribeEvent;
+import org.springframework.web.socket.messaging.SessionUnsubscribeEvent;
 
 /*
  * spring, stomp는 기본적으로 세션관리를 자동으로 내부적으로 처리함
@@ -15,9 +19,11 @@ import org.springframework.web.socket.messaging.SessionDisconnectEvent;
  */
 @Component
 @Slf4j
+@RequiredArgsConstructor
 public class StompEventListener {
 
   private final Set<String> sessions = ConcurrentHashMap.newKeySet();
+  private final StompSessionRoutingService stompSessionRoutingService;
 
   @EventListener
   public void connectHandle(SessionConnectEvent event) {
@@ -25,6 +31,13 @@ public class StompEventListener {
     sessions.add(accessor.getSessionId());
     log.info("Connect sessionId " + accessor.getSessionId());
     log.info("Total session : " + sessions.size());
+    // userId 추출 및 Redis 등록
+    Object userIdObj = accessor.getSessionAttributes() != null ? accessor.getSessionAttributes().get("userId") : null;
+    if (userIdObj instanceof Long) {
+      stompSessionRoutingService.registerSession((Long) userIdObj, accessor.getSessionId());
+    } else {
+      log.warn("userId not found in session attributes for sessionId {}", accessor.getSessionId());
+    }
   }
 
   @EventListener
@@ -33,5 +46,49 @@ public class StompEventListener {
     sessions.remove(accessor.getSessionId());
     log.info("Disconnect sessionId " + accessor.getSessionId());
     log.info("Total session : " + sessions.size());
+    // 모든 프로젝트 Set에서 sessionId 제거
+    stompSessionRoutingService.removeSessionFromAllProjects(accessor.getSessionId());
+    // userId 추출 및 Redis 해제
+    Object userIdObj = accessor.getSessionAttributes() != null ? accessor.getSessionAttributes().get("userId") : null;
+    if (userIdObj instanceof Long) {
+      stompSessionRoutingService.unregisterSession((Long) userIdObj);
+    } else {
+      log.warn("userId not found in session attributes for sessionId {} (disconnect)", accessor.getSessionId());
+    }
+  }
+
+  @EventListener
+  public void handleSubscribeEvent(SessionSubscribeEvent event) {
+    StompHeaderAccessor accessor = StompHeaderAccessor.wrap(event.getMessage());
+    String destination = accessor.getDestination(); // 예: /topic/project/123
+    String sessionId = accessor.getSessionId();
+    Long projectId = extractProjectIdFromDestination(destination);
+    if (projectId != null && sessionId != null) {
+      stompSessionRoutingService.registerProjectSession(projectId, sessionId);
+      log.info("Registered session {} for project {} (subscribe)", sessionId, projectId);
+    }
+  }
+
+  @EventListener
+  public void handleUnsubscribeEvent(SessionUnsubscribeEvent event) {
+    StompHeaderAccessor accessor = StompHeaderAccessor.wrap(event.getMessage());
+    String destination = accessor.getDestination();
+    String sessionId = accessor.getSessionId();
+    Long projectId = extractProjectIdFromDestination(destination);
+    if (projectId != null && sessionId != null) {
+      stompSessionRoutingService.unregisterProjectSession(projectId, sessionId);
+      log.info("Unregistered session {} for project {} (unsubscribe)", sessionId, projectId);
+    }
+  }
+
+  // destination에서 projectId 추출하는 유틸 함수
+  private Long extractProjectIdFromDestination(String destination) {
+    if (destination == null) return null;
+    String[] parts = destination.split("/");
+    try {
+      return Long.valueOf(parts[parts.length - 1]);
+    } catch (Exception e) {
+      return null;
+    }
   }
 }

--- a/src/main/java/com/ellu/looper/stomp/dto/StompPubSubMessage.java
+++ b/src/main/java/com/ellu/looper/stomp/dto/StompPubSubMessage.java
@@ -1,0 +1,17 @@
+package com.ellu.looper.stomp.dto;
+
+import java.io.Serializable;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class StompPubSubMessage implements Serializable {
+    private String targetSessionId;
+    private String eventName;
+    private String data;
+    private String projectId;
+}

--- a/src/main/java/com/ellu/looper/stomp/service/StompPubSubConfig.java
+++ b/src/main/java/com/ellu/looper/stomp/service/StompPubSubConfig.java
@@ -1,0 +1,23 @@
+package com.ellu.looper.stomp.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.listener.ChannelTopic;
+import org.springframework.data.redis.listener.RedisMessageListenerContainer;
+
+@Configuration
+@RequiredArgsConstructor
+public class StompPubSubConfig {
+    private final RedisConnectionFactory redisConnectionFactory;
+    private final StompPubSubListener stompPubSubListener;
+
+    @Bean
+    public RedisMessageListenerContainer stompRedisMessageListenerContainer() {
+        RedisMessageListenerContainer container = new RedisMessageListenerContainer();
+        container.setConnectionFactory(redisConnectionFactory);
+        container.addMessageListener(stompPubSubListener, new ChannelTopic("stomp:events"));
+        return container;
+    }
+} 

--- a/src/main/java/com/ellu/looper/stomp/service/StompPubSubListener.java
+++ b/src/main/java/com/ellu/looper/stomp/service/StompPubSubListener.java
@@ -1,0 +1,30 @@
+package com.ellu.looper.stomp.service;
+
+import com.ellu.looper.stomp.dto.StompPubSubMessage;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.connection.Message;
+import org.springframework.data.redis.connection.MessageListener;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class StompPubSubListener implements MessageListener {
+    private final StompSessionRoutingService stompSessionRoutingService;
+    private final GenericJackson2JsonRedisSerializer serializer = new GenericJackson2JsonRedisSerializer();
+
+    @Override
+    public void onMessage(Message message, byte[] pattern) {
+        try {
+            StompPubSubMessage pubSubMessage = (StompPubSubMessage) serializer.deserialize(message.getBody());
+            if (pubSubMessage == null) return;
+            String sessionId = pubSubMessage.getTargetSessionId();
+            stompSessionRoutingService.sendToLocalSession(sessionId, pubSubMessage.getEventName(), pubSubMessage.getData(), pubSubMessage.getProjectId());
+            log.info("[STOMP] Received pubsub message for session {}: event={}, data={}", sessionId, pubSubMessage.getEventName(), pubSubMessage.getData());
+        } catch (Exception e) {
+            log.error("Failed to process STOMP PubSub message", e);
+        }
+    }
+} 

--- a/src/main/java/com/ellu/looper/stomp/service/StompService.java
+++ b/src/main/java/com/ellu/looper/stomp/service/StompService.java
@@ -6,8 +6,6 @@ import com.ellu.looper.kafka.dto.ScheduleEventMessage;
 import com.ellu.looper.schedule.dto.ProjectScheduleCreateRequest;
 import com.ellu.looper.schedule.dto.ProjectScheduleTakeRequest;
 import com.ellu.looper.schedule.dto.StompProjectScheduleUpdateRequest;
-import com.ellu.looper.schedule.repository.ProjectScheduleRepository;
-import com.ellu.looper.schedule.service.ProjectScheduleService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -16,10 +14,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 public class StompService {
 
-  private final ProjectScheduleService projectScheduleService;
   private final ScheduleEventProducer scheduleEventProducer;
-  private final ProjectScheduleRepository projectScheduleRepository;
-
   @Transactional
   public void updateSchedule(
       Long projectId, StompProjectScheduleUpdateRequest scheduleUpdateRequest, Long userId) {

--- a/src/main/java/com/ellu/looper/stomp/service/StompSessionRoutingService.java
+++ b/src/main/java/com/ellu/looper/stomp/service/StompSessionRoutingService.java
@@ -1,0 +1,127 @@
+package com.ellu.looper.stomp.service;
+
+import com.ellu.looper.stomp.dto.StompPubSubMessage;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.stereotype.Service;
+import java.util.concurrent.TimeUnit;
+import java.util.Set;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class StompSessionRoutingService {
+    private final RedisTemplate<String, Object> redisTemplate;
+    private final SimpMessagingTemplate messagingTemplate;
+    private static final String ROUTING_KEY_PREFIX = "stomp:routing:";
+    private static final String STOMP_CHANNEL = "stomp:events";
+    private static final long SESSION_TIMEOUT_HOURS = 1L;
+    private static final String PROJECT_SESSION_SET_PREFIX = "project:calendar:";
+    private final ObjectMapper objectMapper;
+    private final Map<String, Boolean> localSessionMap = new ConcurrentHashMap<>();
+
+
+    // 세션 등록
+    public void registerSession(Long userId, String sessionId) {
+        String key = ROUTING_KEY_PREFIX + userId;
+        redisTemplate.opsForValue().set(key, sessionId, SESSION_TIMEOUT_HOURS, TimeUnit.HOURS);
+        localSessionMap.put(sessionId, true);
+        log.info("Registered STOMP session {} for user {}", sessionId, userId);
+    }
+
+    // 세션 해제
+    public void unregisterSession(Long userId) {
+        String key = ROUTING_KEY_PREFIX + userId;
+        redisTemplate.delete(key);
+        localSessionMap.remove(getSessionId(userId));
+        log.info("Unregistered STOMP session for user {}", userId);
+    }
+
+    // 메시지 포워딩 (Pub/Sub)
+    public void forwardToSession(Object message) {
+        redisTemplate.convertAndSend(STOMP_CHANNEL, message);
+        log.info("Published STOMP message to channel {}", STOMP_CHANNEL);
+    }
+
+    // 실제 세션에 메시지 전송
+    public void sendToLocalSession(String sessionId, String eventName, String data, String projectId) {
+        String destination = "/topic/" + projectId;
+        messagingTemplate.convertAndSend(destination, data);
+        log.info("[STOMP] Sent message to local session {}: event={}, data={}", sessionId, eventName, data);
+    }
+
+    // 프로젝트 단위 세션 등록
+    public void registerProjectSession(Long projectId, String sessionId) {
+        String key = PROJECT_SESSION_SET_PREFIX + projectId;
+        redisTemplate.opsForSet().add(key, sessionId);
+        // 세션 만료 관리(옵션): 일정 시간 후 자동 삭제
+        redisTemplate.expire(key, SESSION_TIMEOUT_HOURS, TimeUnit.HOURS);
+        log.info("Registered session {} to project {} set", sessionId, projectId);
+    }
+
+    // 프로젝트 단위 세션 해제
+    public void unregisterProjectSession(Long projectId, String sessionId) {
+        String key = PROJECT_SESSION_SET_PREFIX + projectId;
+        redisTemplate.opsForSet().remove(key, sessionId);
+        log.info("Unregistered session {} from project {} set", sessionId, projectId);
+    }
+
+    // 프로젝트 단위 세션 Set 조회
+    public Set<String> getProjectSessionIds(Long projectId) {
+        String key = PROJECT_SESSION_SET_PREFIX + projectId;
+        Set<Object> rawSet = redisTemplate.opsForSet().members(key);
+        if (rawSet == null) return Set.of();
+        // Object -> String 변환
+        return rawSet.stream().filter(String.class::isInstance).map(String.class::cast).collect(java.util.stream.Collectors.toSet());
+    }
+
+    // 세션 조회
+    public String getSessionId(Long userId) {
+        String key = ROUTING_KEY_PREFIX + userId;
+        Object value = redisTemplate.opsForValue().get(key);
+        if (value instanceof String) {
+            return (String) value;
+        }
+        return null;
+    }
+
+    // 현재 pod에 세션이 존재하는지 판별
+    public boolean isCurrentSession(String sessionId) {
+        return localSessionMap.containsKey(sessionId);
+    }
+
+    // 특정 sessionId에게 메시지 전송 (stateless 라우팅/포워딩)
+    public void sendMessageToUser(String sessionId, String eventName, Object payload, String projectId) {
+        String data;
+        try {
+            data = objectMapper.writeValueAsString(payload);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException("Failed to serialize payload", e);
+        }
+        if (isCurrentSession(sessionId)) {
+            // 현재 pod에 세션이 있으면 직접 전송
+            sendToLocalSession(sessionId, eventName, data, projectId);
+        } else {
+            // Pub/Sub으로 포워딩
+            StompPubSubMessage pubSubMessage = new StompPubSubMessage(sessionId, eventName, data, projectId);
+            forwardToSession(pubSubMessage);
+        }
+    }
+
+    // 모든 프로젝트 Set에서 해당 sessionId를 제거
+    public void removeSessionFromAllProjects(String sessionId) {
+        Set<String> keys = redisTemplate.keys(PROJECT_SESSION_SET_PREFIX + "*");
+        if (keys != null) {
+            for (String key : keys) {
+                redisTemplate.opsForSet().remove(key, sessionId);
+            }
+        }
+        log.info("Removed session {} from all project sets", sessionId);
+    }
+} 


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택) 
- [x] 버그 수정 

## 📌 개요
- Redis Pub/Sub 기반으로 다중 Kubernetes Pod 환경에서도 정상 작동하도록 개선함 

- 같은 Pod 내, 다른 Pod 간에도 메시지가 정상 전달되도록 구성
- 서버 인스턴스 수와 무관하게 메시징이 작동하도록 서버 로직을 Stateless하게 개선
- SSE, WS 연결 정보를 Redis에 공유 저장소로 관리
- Redis Pub/Sub을 도입해 Pod 간 메시지 브로드캐스트 처리

## ✅ 체크 리스트
- [x] 코드가 정상적으로 컴파일되는지 확인했습니다.
- [x] PR이 관련 이슈를 정확히 참조하고, 적절한 라벨을 선택했습니다.
- [ ] 모든 테스트가 성공적으로 통과했습니다.
- [ ] 관련 문서를 WIKI에 업데이트했습니다.
- [ ] 코드 스타일 가이드라인을 준수했습니다.
- [ ] 코드 리뷰어를 지정했습니다.