### PR TITLE
fix: sse 세션 타임아웃 핸들링

### DIFF
--- a/src/main/java/com/ellu/looper/chat/dto/MessageRequest.java
+++ b/src/main/java/com/ellu/looper/chat/dto/MessageRequest.java
@@ -20,5 +20,6 @@ public class MessageRequest {
 
   @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss")
   private LocalDateTime date;
+
   private UUID messageId;
 }

--- a/src/main/java/com/ellu/looper/config/SecurityConfig.java
+++ b/src/main/java/com/ellu/looper/config/SecurityConfig.java
@@ -60,7 +60,11 @@ public class SecurityConfig {
     CorsConfiguration configuration = new CorsConfiguration();
     configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
     configuration.setAllowedOriginPatterns(
-        List.of("http://localhost:3000","http://localhost:3001", "https://looper.my", "https://dev.looper.my"));
+        List.of(
+            "http://localhost:3000",
+            "http://localhost:3001",
+            "https://looper.my",
+            "https://dev.looper.my"));
     configuration.setAllowedHeaders(List.of("*"));
     configuration.setAllowCredentials(true); // 쿠키 인증 허용
     configuration.setMaxAge(3600L); // 1시간

--- a/src/main/java/com/ellu/looper/config/StompWebsocketConfig.java
+++ b/src/main/java/com/ellu/looper/config/StompWebsocketConfig.java
@@ -23,7 +23,8 @@ public class StompWebsocketConfig implements WebSocketMessageBrokerConfigurer {
     registry
         .addEndpoint("/connect")
         .setAllowedOrigins(
-            "http://localhost:3000","http://localhost:3001",
+            "http://localhost:3000",
+            "http://localhost:3001",
             "https://looper.my",
             "https://dev.looper.my") // websocket관련 cors설정
         .withSockJS(); // ws://가 아닌 http:// endpoint를 사용할 수 있게 해주는 sockJs library를 통한 요청 허용

--- a/src/main/java/com/ellu/looper/fastapi/dto/MeetingNoteRequest.java
+++ b/src/main/java/com/ellu/looper/fastapi/dto/MeetingNoteRequest.java
@@ -1,4 +1,5 @@
 package com.ellu.looper.fastapi.dto;
+
 import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;

--- a/src/main/java/com/ellu/looper/fastapi/dto/MeetingNoteResponse.java
+++ b/src/main/java/com/ellu/looper/fastapi/dto/MeetingNoteResponse.java
@@ -1,4 +1,5 @@
 package com.ellu.looper.fastapi.dto;
+
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.List;
 import lombok.AllArgsConstructor;

--- a/src/main/java/com/ellu/looper/fastapi/service/FastApiService.java
+++ b/src/main/java/com/ellu/looper/fastapi/service/FastApiService.java
@@ -230,7 +230,6 @@ public class FastApiService {
         .subscribe();
   }
 
-
   public MeetingNoteResponse sendNoteToAI(MeetingNoteRequest noteRequest) {
     log.info("Sending note to AI server for project: {}", noteRequest.getProject_id());
     return fastApiSummaryWebClient

--- a/src/main/java/com/ellu/looper/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/ellu/looper/jwt/JwtAuthenticationFilter.java
@@ -51,9 +51,9 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         SecurityContextHolder.getContext().setAuthentication(authentication);
 
         if (userId != null) {
-            // 세션에 userId 저장 (SSE 등에서 사용)
-            HttpSession session = request.getSession(true); // 없으면 생성
-            session.setAttribute("userId", userId);
+          // 세션에 userId 저장 (SSE 등에서 사용)
+          HttpSession session = request.getSession(true); // 없으면 생성
+          session.setAttribute("userId", userId);
         }
 
       } catch (JwtException e) {

--- a/src/main/java/com/ellu/looper/kafka/ChatConsumer.java
+++ b/src/main/java/com/ellu/looper/kafka/ChatConsumer.java
@@ -6,12 +6,9 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.stereotype.Component;
-import org.springframework.data.redis.core.RedisTemplate;
-import java.time.format.DateTimeFormatter;
-import java.util.concurrent.TimeUnit;
-import java.util.UUID;
 
 @Slf4j
 @Component

--- a/src/main/java/com/ellu/looper/kafka/ChatConsumer.java
+++ b/src/main/java/com/ellu/looper/kafka/ChatConsumer.java
@@ -34,19 +34,6 @@ public class ChatConsumer {
 
       MessageRequest message = objectMapper.readValue(value, MessageRequest.class);
 
-      // 메시지에 messageId가 없으면 UUID 생성해서 할당
-      if (message.getMessageId() == null) {
-        message = message.toBuilder().messageId(UUID.randomUUID()).build();
-      }
-      String uniqueKey = "chat:msg:" + message.getMessageId();
-      Boolean success = redisTemplate.opsForValue().setIfAbsent(uniqueKey, "done", 10, TimeUnit.MINUTES);
-      if (!Boolean.TRUE.equals(success)) {
-        log.info("Duplicate chat message detected, skipping: {}", uniqueKey);
-        return;
-      }
-
-      log.info("Received message from user {}: {}", userId, message.getMessage());
-
       fastApiService
           .streamChatResponse(message)
           .doOnNext(

--- a/src/main/java/com/ellu/looper/kafka/ChatProducer.java
+++ b/src/main/java/com/ellu/looper/kafka/ChatProducer.java
@@ -37,7 +37,7 @@ public class ChatProducer {
   public record ChatResponseWrapper(String message, ChatResponseToken data) {}
 
   public void sendChatbotResponse(Long userId, String rawJson) {
-    if (rawJson.equals("connected")){
+    if (rawJson.equals("connected")) {
       log.info("Skipping SSE handshake message: {}", rawJson);
       return;
     }

--- a/src/main/java/com/ellu/looper/kafka/NotificationConsumer.java
+++ b/src/main/java/com/ellu/looper/kafka/NotificationConsumer.java
@@ -94,7 +94,6 @@ public class NotificationConsumer implements Runnable {
   @Value("${kafka.consumer.notification-group-id}")
   private String NOTIFICATION_GROUP_ID;
 
-
   @PostConstruct
   public void init() {
     log.info("NotificationConsumer init() called");
@@ -242,8 +241,9 @@ public class NotificationConsumer implements Runnable {
                             "Notification with id " + event.getNotificationId() + "not found"));
 
         // 중복 멤버 추가 방지
-        boolean memberExists = projectMemberRepository
-            .existsByProjectAndUserAndDeletedAtIsNull(project, originalNotification.getReceiver());
+        boolean memberExists =
+            projectMemberRepository.existsByProjectAndUserAndDeletedAtIsNull(
+                project, originalNotification.getReceiver());
 
         if (!memberExists) {
           ProjectMember member =

--- a/src/main/java/com/ellu/looper/kafka/ScheduleEventConsumer.java
+++ b/src/main/java/com/ellu/looper/kafka/ScheduleEventConsumer.java
@@ -116,9 +116,13 @@ public class ScheduleEventConsumer implements Runnable {
   }
 
   private void processScheduleEvent(ScheduleEventMessage event) {
-    log.info("Processing schedule event: type={}, projectId={}, userId={}, scheduleId={}", 
-        event.getType(), event.getProjectId(), event.getUserId(), event.getScheduleId());
-    
+    log.info(
+        "Processing schedule event: type={}, projectId={}, userId={}, scheduleId={}",
+        event.getType(),
+        event.getProjectId(),
+        event.getUserId(),
+        event.getScheduleId());
+
     // 실제 프로젝트에 접속 중인 세션
     Long projectId = Long.valueOf(event.getProjectId());
     Set<String> activeSessionIds = stompSessionRoutingService.getProjectSessionIds(projectId);
@@ -131,8 +135,8 @@ public class ScheduleEventConsumer implements Runnable {
           event = event.toBuilder().schedule(projectScheduleService.toDto(response)).build();
           // WebSocket 브로드캐스트 (실제 접속 중인 세션에만)
           for (String sessionId : activeSessionIds) {
-            stompSessionRoutingService.sendMessageToUser(sessionId, "/create",
-                event, event.getProjectId());
+            stompSessionRoutingService.sendMessageToUser(
+                sessionId, "/create", event, event.getProjectId());
           }
         }
         break;
@@ -147,8 +151,8 @@ public class ScheduleEventConsumer implements Runnable {
                 .build();
         // WebSocket 브로드캐스트 (실제 접속 중인 세션에만)
         for (String sessionId : activeSessionIds) {
-          stompSessionRoutingService.sendMessageToUser(sessionId, "/update", event,
-              event.getProjectId());
+          stompSessionRoutingService.sendMessageToUser(
+              sessionId, "/update", event, event.getProjectId());
         }
         break;
 
@@ -169,8 +173,8 @@ public class ScheduleEventConsumer implements Runnable {
                 .build();
         // WebSocket 브로드캐스트 (실제 접속 중인 세션에만)
         for (String sessionId : activeSessionIds) {
-          stompSessionRoutingService.sendMessageToUser(sessionId, "/take",event,
-              event.getProjectId());
+          stompSessionRoutingService.sendMessageToUser(
+              sessionId, "/take", event, event.getProjectId());
         }
         break;
 
@@ -178,8 +182,8 @@ public class ScheduleEventConsumer implements Runnable {
         projectScheduleService.deleteSchedule(event.getScheduleId(), event.getUserId());
         // WebSocket 브로드캐스트 (실제 접속 중인 세션에만)
         for (String sessionId : activeSessionIds) {
-          stompSessionRoutingService.sendMessageToUser(sessionId, "/delete", event,
-              event.getProjectId());
+          stompSessionRoutingService.sendMessageToUser(
+              sessionId, "/delete", event, event.getProjectId());
         }
         break;
     }

--- a/src/main/java/com/ellu/looper/project/controller/MeetingNoteController.java
+++ b/src/main/java/com/ellu/looper/project/controller/MeetingNoteController.java
@@ -11,7 +11,6 @@ import com.ellu.looper.user.repository.UserRepository;
 import java.util.List;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.web.bind.annotation.*;

--- a/src/main/java/com/ellu/looper/project/controller/ProjectController.java
+++ b/src/main/java/com/ellu/looper/project/controller/ProjectController.java
@@ -46,8 +46,7 @@ public class ProjectController {
 
   @PostMapping("/{projectId}/audio")
   public ResponseEntity<ApiResponse<?>> relayAudioToAI(
-      @PathVariable Long projectId,
-      @RequestParam("file") MultipartFile file) throws IOException {
+      @PathVariable Long projectId, @RequestParam("file") MultipartFile file) throws IOException {
 
     // File size limit: 10MB
     if (file.getSize() > 10 * 1024 * 1024) {
@@ -55,7 +54,8 @@ public class ProjectController {
     }
     // File type limit: mp3, mp4, wav
     String contentType = file.getContentType();
-    if (!("audio/mpeg".equals(contentType) || "audio/mp4".equals(contentType)
+    if (!("audio/mpeg".equals(contentType)
+        || "audio/mp4".equals(contentType)
         || "audio/wav".equals(contentType))) {
       return ResponseEntity.badRequest()
           .body(ApiResponse.error("Only mp3, mp4, and wav audio files are allowed."));
@@ -65,13 +65,15 @@ public class ProjectController {
     formData.add("audio_file", file.getResource());
     formData.add("project_id", projectId.toString());
 
-    String aiResponse = webClient.post()
-        .uri("ai/audio")
-        .contentType(MediaType.MULTIPART_FORM_DATA)
-        .body(BodyInserters.fromMultipartData(formData))
-        .retrieve()
-        .bodyToMono(String.class)
-        .block();
+    String aiResponse =
+        webClient
+            .post()
+            .uri("ai/audio")
+            .contentType(MediaType.MULTIPART_FORM_DATA)
+            .body(BodyInserters.fromMultipartData(formData))
+            .retrieve()
+            .bodyToMono(String.class)
+            .block();
     return ResponseEntity.ok(ApiResponse.success("file_sent_to_ai", aiResponse));
   }
 

--- a/src/main/java/com/ellu/looper/schedule/controller/ProjectScheduleController.java
+++ b/src/main/java/com/ellu/looper/schedule/controller/ProjectScheduleController.java
@@ -16,7 +16,6 @@ import java.util.Map;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.format.annotation.DateTimeFormat;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.web.bind.annotation.DeleteMapping;

--- a/src/main/java/com/ellu/looper/schedule/dto/ProjectScheduleUpdateRequest.java
+++ b/src/main/java/com/ellu/looper/schedule/dto/ProjectScheduleUpdateRequest.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import java.time.LocalDateTime;
-import java.util.List;
 
 public record ProjectScheduleUpdateRequest(
     @NotBlank String title,

--- a/src/main/java/com/ellu/looper/sse/dto/SsePubSubMessage.java
+++ b/src/main/java/com/ellu/looper/sse/dto/SsePubSubMessage.java
@@ -9,7 +9,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class SsePubSubMessage implements Serializable {
-    private String targetSessionId;
-    private String eventName;
-    private String data;
-} 
+  private String targetSessionId;
+  private String eventName;
+  private String data;
+}

--- a/src/main/java/com/ellu/looper/sse/service/ChatSseService.java
+++ b/src/main/java/com/ellu/looper/sse/service/ChatSseService.java
@@ -4,15 +4,15 @@ import com.ellu.looper.sse.dto.SsePubSubMessage;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import jakarta.servlet.http.HttpServletRequest;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
-import jakarta.servlet.http.HttpServletRequest;
-import org.springframework.data.redis.core.RedisTemplate;
-import java.util.concurrent.TimeUnit;
 
 @Slf4j
 @Service
@@ -24,7 +24,6 @@ public class ChatSseService {
   private final RedisTemplate<String, Object> redisTemplate;
   private static final String routingKeyPrefix = "sse:routing:chat:";
   private static final String SSE_CHANNEL = "sse:events";
-
 
   public SseEmitter createEmitter(HttpServletRequest request, Long userId) {
     String sessionId = request.getSession().getId();
@@ -126,7 +125,6 @@ public class ChatSseService {
     }
   }
 
-
   public void sendToken(Long userId, String sessionId, String token, boolean done) {
     try {
       String targetSessionId = getTargetSession(userId);
@@ -138,12 +136,12 @@ public class ChatSseService {
 
         SseEmitter localEmitter = getEmitter(sessionId);
         if (localEmitter != null) {
-          sendToLocalSession(sessionId, "token",
-              "{\"token\":\"" + token + "\",\"done\":" + done + "}");
+          sendToLocalSession(
+              sessionId, "token", "{\"token\":\"" + token + "\",\"done\":" + done + "}");
         }
       } else {
-        forwardToSession(targetSessionId, "token",
-            "{\"token\":\"" + token + "\",\"done\":" + done + "}");
+        forwardToSession(
+            targetSessionId, "token", "{\"token\":\"" + token + "\",\"done\":" + done + "}");
       }
     } catch (Exception e) {
       log.error("Error sending message to session {}: {}", sessionId, e.getMessage());
@@ -173,12 +171,12 @@ public class ChatSseService {
 
         SseEmitter localEmitter = getEmitter(sessionId);
         if (localEmitter != null) {
-          sendToLocalSession(sessionId, "message",
-              "{\"message\":\"" + message + "\",\"done\":" + done + "}");
+          sendToLocalSession(
+              sessionId, "message", "{\"message\":\"" + message + "\",\"done\":" + done + "}");
         }
       } else {
-        forwardToSession(targetSessionId, "message",
-            "{\"message\":\"" + message + "\",\"done\":" + done + "}");
+        forwardToSession(
+            targetSessionId, "message", "{\"message\":\"" + message + "\",\"done\":" + done + "}");
       }
     } catch (Exception e) {
       log.error("Error sending message to session {}: {}", sessionId, e.getMessage());
@@ -188,7 +186,8 @@ public class ChatSseService {
   }
 
   // userId로부터 sessionId를 조회해 메시지 전송
-  public void sendSchedulePreviewToUser(Long userId,
+  public void sendSchedulePreviewToUser(
+      Long userId,
       String taskTitle,
       String category,
       String subtaskTitle,
@@ -197,8 +196,8 @@ public class ChatSseService {
       boolean done) {
     String sessionId = (String) redisTemplate.opsForValue().get(routingKeyPrefix + userId);
     if (sessionId != null) {
-      sendSchedulePreview(userId, sessionId, taskTitle, category, subtaskTitle, startTime, endTime,
-          done);
+      sendSchedulePreview(
+          userId, sessionId, taskTitle, category, subtaskTitle, startTime, endTime, done);
     } else {
       log.warn("No sessionId found for userId {} when trying to send message", userId);
     }

--- a/src/main/java/com/ellu/looper/sse/service/NotificationSseService.java
+++ b/src/main/java/com/ellu/looper/sse/service/NotificationSseService.java
@@ -1,17 +1,17 @@
 package com.ellu.looper.sse.service;
 
 import com.ellu.looper.kafka.dto.NotificationMessage;
+import com.ellu.looper.sse.dto.SsePubSubMessage;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.http.HttpServletRequest;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.stereotype.Service;
-import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
-import com.ellu.looper.sse.dto.SsePubSubMessage;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 @Service
 @Slf4j
@@ -86,13 +86,17 @@ public class NotificationSseService {
   public void sendToLocalSession(String sessionId, String eventName, String data) {
     try {
       if (sessionId == null) {
-        log.error("sendToLocalSession called with null sessionId. eventName: {}, data: {}",
-            eventName, data);
+        log.error(
+            "sendToLocalSession called with null sessionId. eventName: {}, data: {}",
+            eventName,
+            data);
         return;
       }
       if (data == null) {
-        log.error("sendToLocalSession called with null data for sessionId: {}, eventName: {}",
-            sessionId, eventName);
+        log.error(
+            "sendToLocalSession called with null data for sessionId: {}, eventName: {}",
+            sessionId,
+            eventName);
         return;
       }
       NotificationMessage notificationMessage;
@@ -101,7 +105,10 @@ public class NotificationSseService {
       } catch (Exception parseEx) {
         log.error(
             "Failed to parse data to NotificationMessage for sessionId: {}, eventName: {}, data: {}",
-            sessionId, eventName, data, parseEx);
+            sessionId,
+            eventName,
+            data,
+            parseEx);
         return;
       }
       SseEmitter emitter = getEmitter(sessionId);
@@ -132,20 +139,23 @@ public class NotificationSseService {
     return sessionId.equals(redisSession) && emitters.containsKey(sessionId);
   }
 
-  private void forwardToSession(String targetSessionId, String eventName,
-      NotificationMessage data) {
+  private void forwardToSession(
+      String targetSessionId, String eventName, NotificationMessage data) {
     try {
       String jsonData = objectMapper.writeValueAsString(data);
       SsePubSubMessage message = new SsePubSubMessage(targetSessionId, eventName, jsonData);
       redisTemplate.convertAndSend(SSE_CHANNEL, message);
-      log.info("Published notification SSE message to channel {} for session {}", SSE_CHANNEL,
+      log.info(
+          "Published notification SSE message to channel {} for session {}",
+          SSE_CHANNEL,
           targetSessionId);
     } catch (Exception e) {
-      log.error("Error publishing notification SSE message to channel {}: {}", SSE_CHANNEL,
+      log.error(
+          "Error publishing notification SSE message to channel {}: {}",
+          SSE_CHANNEL,
           e.getMessage());
     }
   }
-
 
   // userId로부터 sessionId를 조회해 메시지 전송
   public void sendNotificationToUser(Long userId, NotificationMessage dto) {

--- a/src/main/java/com/ellu/looper/sse/service/SsePubSubConfig.java
+++ b/src/main/java/com/ellu/looper/sse/service/SsePubSubConfig.java
@@ -10,14 +10,14 @@ import org.springframework.data.redis.listener.RedisMessageListenerContainer;
 @Configuration
 @RequiredArgsConstructor
 public class SsePubSubConfig {
-    private final RedisConnectionFactory redisConnectionFactory;
-    private final SsePubSubListener ssePubSubListener;
+  private final RedisConnectionFactory redisConnectionFactory;
+  private final SsePubSubListener ssePubSubListener;
 
-    @Bean
-    public RedisMessageListenerContainer redisMessageListenerContainer() {
-        RedisMessageListenerContainer container = new RedisMessageListenerContainer();
-        container.setConnectionFactory(redisConnectionFactory);
-        container.addMessageListener(ssePubSubListener, new ChannelTopic("sse:events"));
-        return container;
-    }
-} 
+  @Bean
+  public RedisMessageListenerContainer redisMessageListenerContainer() {
+    RedisMessageListenerContainer container = new RedisMessageListenerContainer();
+    container.setConnectionFactory(redisConnectionFactory);
+    container.addMessageListener(ssePubSubListener, new ChannelTopic("sse:events"));
+    return container;
+  }
+}

--- a/src/main/java/com/ellu/looper/sse/service/SsePubSubListener.java
+++ b/src/main/java/com/ellu/looper/sse/service/SsePubSubListener.java
@@ -12,26 +12,29 @@ import org.springframework.stereotype.Component;
 @Component
 @RequiredArgsConstructor
 public class SsePubSubListener implements MessageListener {
-    private final ChatSseService chatSseService;
-    private final NotificationSseService notificationSseService;
-    private final GenericJackson2JsonRedisSerializer serializer = new GenericJackson2JsonRedisSerializer(); // SsePubSubMessage.class 지정 불필요
+  private final ChatSseService chatSseService;
+  private final NotificationSseService notificationSseService;
+  private final GenericJackson2JsonRedisSerializer serializer =
+      new GenericJackson2JsonRedisSerializer(); // SsePubSubMessage.class 지정 불필요
 
-    @Override
-    public void onMessage(Message message, byte[] pattern) {
-        try {
-            SsePubSubMessage pubSubMessage = (SsePubSubMessage) serializer.deserialize(message.getBody());
-            if (pubSubMessage == null) return;
-            String sessionId = pubSubMessage.getTargetSessionId();
-            if (chatSseService.getEmitter(sessionId) != null) {
-                chatSseService.sendToLocalSession(sessionId, pubSubMessage.getEventName(), pubSubMessage.getData());
-                log.info("Delivered chat SSE message to local session {} via PubSub", sessionId);
-            }
-            if (notificationSseService.getEmitter(sessionId) != null) {
-                notificationSseService.sendToLocalSession(sessionId, pubSubMessage.getEventName(), pubSubMessage.getData());
-                log.info("Delivered notification SSE message to local session {} via PubSub", sessionId);
-            }
-        } catch (Exception e) {
-            log.error("Failed to process SSE PubSub message", e);
-        }
+  @Override
+  public void onMessage(Message message, byte[] pattern) {
+    try {
+      SsePubSubMessage pubSubMessage = (SsePubSubMessage) serializer.deserialize(message.getBody());
+      if (pubSubMessage == null) return;
+      String sessionId = pubSubMessage.getTargetSessionId();
+      if (chatSseService.getEmitter(sessionId) != null) {
+        chatSseService.sendToLocalSession(
+            sessionId, pubSubMessage.getEventName(), pubSubMessage.getData());
+        log.info("Delivered chat SSE message to local session {} via PubSub", sessionId);
+      }
+      if (notificationSseService.getEmitter(sessionId) != null) {
+        notificationSseService.sendToLocalSession(
+            sessionId, pubSubMessage.getEventName(), pubSubMessage.getData());
+        log.info("Delivered notification SSE message to local session {} via PubSub", sessionId);
+      }
+    } catch (Exception e) {
+      log.error("Failed to process SSE PubSub message", e);
     }
-} 
+  }
+}

--- a/src/main/java/com/ellu/looper/stomp/StompEventListener.java
+++ b/src/main/java/com/ellu/looper/stomp/StompEventListener.java
@@ -1,15 +1,15 @@
 package com.ellu.looper.stomp;
 
+import com.ellu.looper.stomp.service.StompSessionRoutingService;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.event.EventListener;
 import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
 import org.springframework.stereotype.Component;
 import org.springframework.web.socket.messaging.SessionConnectEvent;
 import org.springframework.web.socket.messaging.SessionDisconnectEvent;
-import com.ellu.looper.stomp.service.StompSessionRoutingService;
-import lombok.RequiredArgsConstructor;
 import org.springframework.web.socket.messaging.SessionSubscribeEvent;
 import org.springframework.web.socket.messaging.SessionUnsubscribeEvent;
 
@@ -32,7 +32,10 @@ public class StompEventListener {
     log.info("Connect sessionId " + accessor.getSessionId());
     log.info("Total session : " + sessions.size());
     // userId 추출 및 Redis 등록
-    Object userIdObj = accessor.getSessionAttributes() != null ? accessor.getSessionAttributes().get("userId") : null;
+    Object userIdObj =
+        accessor.getSessionAttributes() != null
+            ? accessor.getSessionAttributes().get("userId")
+            : null;
     if (userIdObj instanceof Long) {
       stompSessionRoutingService.registerSession((Long) userIdObj, accessor.getSessionId());
     } else {
@@ -49,11 +52,16 @@ public class StompEventListener {
     // 모든 프로젝트 Set에서 sessionId 제거
     stompSessionRoutingService.removeSessionFromAllProjects(accessor.getSessionId());
     // userId 추출 및 Redis 해제
-    Object userIdObj = accessor.getSessionAttributes() != null ? accessor.getSessionAttributes().get("userId") : null;
+    Object userIdObj =
+        accessor.getSessionAttributes() != null
+            ? accessor.getSessionAttributes().get("userId")
+            : null;
     if (userIdObj instanceof Long) {
       stompSessionRoutingService.unregisterSession((Long) userIdObj);
     } else {
-      log.warn("userId not found in session attributes for sessionId {} (disconnect)", accessor.getSessionId());
+      log.warn(
+          "userId not found in session attributes for sessionId {} (disconnect)",
+          accessor.getSessionId());
     }
   }
 

--- a/src/main/java/com/ellu/looper/stomp/dto/StompPubSubMessage.java
+++ b/src/main/java/com/ellu/looper/stomp/dto/StompPubSubMessage.java
@@ -2,7 +2,6 @@ package com.ellu.looper.stomp.dto;
 
 import java.io.Serializable;
 import lombok.AllArgsConstructor;
-import lombok.Data;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -10,8 +9,8 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class StompPubSubMessage implements Serializable {
-    private String targetSessionId;
-    private String eventName;
-    private String data;
-    private String projectId;
+  private String targetSessionId;
+  private String eventName;
+  private String data;
+  private String projectId;
 }

--- a/src/main/java/com/ellu/looper/stomp/service/StompPubSubConfig.java
+++ b/src/main/java/com/ellu/looper/stomp/service/StompPubSubConfig.java
@@ -10,14 +10,14 @@ import org.springframework.data.redis.listener.RedisMessageListenerContainer;
 @Configuration
 @RequiredArgsConstructor
 public class StompPubSubConfig {
-    private final RedisConnectionFactory redisConnectionFactory;
-    private final StompPubSubListener stompPubSubListener;
+  private final RedisConnectionFactory redisConnectionFactory;
+  private final StompPubSubListener stompPubSubListener;
 
-    @Bean
-    public RedisMessageListenerContainer stompRedisMessageListenerContainer() {
-        RedisMessageListenerContainer container = new RedisMessageListenerContainer();
-        container.setConnectionFactory(redisConnectionFactory);
-        container.addMessageListener(stompPubSubListener, new ChannelTopic("stomp:events"));
-        return container;
-    }
-} 
+  @Bean
+  public RedisMessageListenerContainer stompRedisMessageListenerContainer() {
+    RedisMessageListenerContainer container = new RedisMessageListenerContainer();
+    container.setConnectionFactory(redisConnectionFactory);
+    container.addMessageListener(stompPubSubListener, new ChannelTopic("stomp:events"));
+    return container;
+  }
+}

--- a/src/main/java/com/ellu/looper/stomp/service/StompPubSubListener.java
+++ b/src/main/java/com/ellu/looper/stomp/service/StompPubSubListener.java
@@ -12,19 +12,29 @@ import org.springframework.stereotype.Component;
 @Component
 @RequiredArgsConstructor
 public class StompPubSubListener implements MessageListener {
-    private final StompSessionRoutingService stompSessionRoutingService;
-    private final GenericJackson2JsonRedisSerializer serializer = new GenericJackson2JsonRedisSerializer();
+  private final StompSessionRoutingService stompSessionRoutingService;
+  private final GenericJackson2JsonRedisSerializer serializer =
+      new GenericJackson2JsonRedisSerializer();
 
-    @Override
-    public void onMessage(Message message, byte[] pattern) {
-        try {
-            StompPubSubMessage pubSubMessage = (StompPubSubMessage) serializer.deserialize(message.getBody());
-            if (pubSubMessage == null) return;
-            String sessionId = pubSubMessage.getTargetSessionId();
-            stompSessionRoutingService.sendToLocalSession(sessionId, pubSubMessage.getEventName(), pubSubMessage.getData(), pubSubMessage.getProjectId());
-            log.info("[STOMP] Received pubsub message for session {}: event={}, data={}", sessionId, pubSubMessage.getEventName(), pubSubMessage.getData());
-        } catch (Exception e) {
-            log.error("Failed to process STOMP PubSub message", e);
-        }
+  @Override
+  public void onMessage(Message message, byte[] pattern) {
+    try {
+      StompPubSubMessage pubSubMessage =
+          (StompPubSubMessage) serializer.deserialize(message.getBody());
+      if (pubSubMessage == null) return;
+      String sessionId = pubSubMessage.getTargetSessionId();
+      stompSessionRoutingService.sendToLocalSession(
+          sessionId,
+          pubSubMessage.getEventName(),
+          pubSubMessage.getData(),
+          pubSubMessage.getProjectId());
+      log.info(
+          "[STOMP] Received pubsub message for session {}: event={}, data={}",
+          sessionId,
+          pubSubMessage.getEventName(),
+          pubSubMessage.getData());
+    } catch (Exception e) {
+      log.error("Failed to process STOMP PubSub message", e);
     }
-} 
+  }
+}

--- a/src/main/java/com/ellu/looper/stomp/service/StompService.java
+++ b/src/main/java/com/ellu/looper/stomp/service/StompService.java
@@ -15,6 +15,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class StompService {
 
   private final ScheduleEventProducer scheduleEventProducer;
+
   @Transactional
   public void updateSchedule(
       Long projectId, StompProjectScheduleUpdateRequest scheduleUpdateRequest, Long userId) {

--- a/src/main/java/com/ellu/looper/stomp/service/StompSessionRoutingService.java
+++ b/src/main/java/com/ellu/looper/stomp/service/StompSessionRoutingService.java
@@ -4,127 +4,133 @@ import com.ellu.looper.stomp.dto.StompPubSubMessage;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Service;
-import java.util.concurrent.TimeUnit;
-import java.util.Set;
 
 @Slf4j
 @Service
 @RequiredArgsConstructor
 public class StompSessionRoutingService {
-    private final RedisTemplate<String, Object> redisTemplate;
-    private final SimpMessagingTemplate messagingTemplate;
-    private static final String ROUTING_KEY_PREFIX = "stomp:routing:";
-    private static final String STOMP_CHANNEL = "stomp:events";
-    private static final long SESSION_TIMEOUT_HOURS = 1L;
-    private static final String PROJECT_SESSION_SET_PREFIX = "project:calendar:";
-    private final ObjectMapper objectMapper;
-    private final Map<String, Boolean> localSessionMap = new ConcurrentHashMap<>();
+  private final RedisTemplate<String, Object> redisTemplate;
+  private final SimpMessagingTemplate messagingTemplate;
+  private static final String ROUTING_KEY_PREFIX = "stomp:routing:";
+  private static final String STOMP_CHANNEL = "stomp:events";
+  private static final long SESSION_TIMEOUT_HOURS = 1L;
+  private static final String PROJECT_SESSION_SET_PREFIX = "project:calendar:";
+  private final ObjectMapper objectMapper;
+  private final Map<String, Boolean> localSessionMap = new ConcurrentHashMap<>();
 
+  // 세션 등록
+  public void registerSession(Long userId, String sessionId) {
+    String key = ROUTING_KEY_PREFIX + userId;
+    redisTemplate.opsForValue().set(key, sessionId, SESSION_TIMEOUT_HOURS, TimeUnit.HOURS);
+    localSessionMap.put(sessionId, true);
+    log.info("Registered STOMP session {} for user {}", sessionId, userId);
+  }
 
-    // 세션 등록
-    public void registerSession(Long userId, String sessionId) {
-        String key = ROUTING_KEY_PREFIX + userId;
-        redisTemplate.opsForValue().set(key, sessionId, SESSION_TIMEOUT_HOURS, TimeUnit.HOURS);
-        localSessionMap.put(sessionId, true);
-        log.info("Registered STOMP session {} for user {}", sessionId, userId);
+  // 세션 해제
+  public void unregisterSession(Long userId) {
+    String key = ROUTING_KEY_PREFIX + userId;
+    redisTemplate.delete(key);
+    String sessionId = getSessionId(userId);
+    if (sessionId != null) {
+      localSessionMap.remove(sessionId);
     }
+    log.info("Unregistered STOMP session for user {}", userId);
+  }
 
-    // 세션 해제
-    public void unregisterSession(Long userId) {
-        String key = ROUTING_KEY_PREFIX + userId;
-        redisTemplate.delete(key);
-        String sessionId = getSessionId(userId);
-        if (sessionId != null) {
-            localSessionMap.remove(sessionId);
-        }
-        log.info("Unregistered STOMP session for user {}", userId);
+  // 메시지 포워딩 (Pub/Sub)
+  public void forwardToSession(Object message) {
+    redisTemplate.convertAndSend(STOMP_CHANNEL, message);
+    log.info("Published STOMP message to channel {}", STOMP_CHANNEL);
+  }
+
+  // 실제 세션에 메시지 전송
+  public void sendToLocalSession(
+      String sessionId, String eventName, String data, String projectId) {
+    String destination = "/topic/" + projectId;
+    messagingTemplate.convertAndSend(destination, data);
+    log.info(
+        "[STOMP] Sent message to local session {}: event={}, data={}", sessionId, eventName, data);
+  }
+
+  // 프로젝트 단위 세션 등록
+  public void registerProjectSession(Long projectId, String sessionId) {
+    String key = PROJECT_SESSION_SET_PREFIX + projectId;
+    redisTemplate.opsForSet().add(key, sessionId);
+    // 세션 만료 관리(옵션): 일정 시간 후 자동 삭제
+    redisTemplate.expire(key, SESSION_TIMEOUT_HOURS, TimeUnit.HOURS);
+    log.info("Registered session {} to project {} set", sessionId, projectId);
+  }
+
+  // 프로젝트 단위 세션 해제
+  public void unregisterProjectSession(Long projectId, String sessionId) {
+    String key = PROJECT_SESSION_SET_PREFIX + projectId;
+    redisTemplate.opsForSet().remove(key, sessionId);
+    log.info("Unregistered session {} from project {} set", sessionId, projectId);
+  }
+
+  // 프로젝트 단위 세션 Set 조회
+  public Set<String> getProjectSessionIds(Long projectId) {
+    String key = PROJECT_SESSION_SET_PREFIX + projectId;
+    Set<Object> rawSet = redisTemplate.opsForSet().members(key);
+    if (rawSet == null) return Set.of();
+    // Object -> String 변환
+    return rawSet.stream()
+        .filter(String.class::isInstance)
+        .map(String.class::cast)
+        .collect(java.util.stream.Collectors.toSet());
+  }
+
+  // 세션 조회
+  public String getSessionId(Long userId) {
+    String key = ROUTING_KEY_PREFIX + userId;
+    Object value = redisTemplate.opsForValue().get(key);
+    if (value instanceof String) {
+      return (String) value;
     }
+    return null;
+  }
 
-    // 메시지 포워딩 (Pub/Sub)
-    public void forwardToSession(Object message) {
-        redisTemplate.convertAndSend(STOMP_CHANNEL, message);
-        log.info("Published STOMP message to channel {}", STOMP_CHANNEL);
+  // 현재 pod에 세션이 존재하는지 판별
+  public boolean isCurrentSession(String sessionId) {
+    return localSessionMap.containsKey(sessionId);
+  }
+
+  // 특정 sessionId에게 메시지 전송 (stateless 라우팅/포워딩)
+  public void sendMessageToUser(
+      String sessionId, String eventName, Object payload, String projectId) {
+    String data;
+    try {
+      data = objectMapper.writeValueAsString(payload);
+    } catch (JsonProcessingException e) {
+      throw new RuntimeException("Failed to serialize payload", e);
     }
-
-    // 실제 세션에 메시지 전송
-    public void sendToLocalSession(String sessionId, String eventName, String data, String projectId) {
-        String destination = "/topic/" + projectId;
-        messagingTemplate.convertAndSend(destination, data);
-        log.info("[STOMP] Sent message to local session {}: event={}, data={}", sessionId, eventName, data);
+    if (isCurrentSession(sessionId)) {
+      // 현재 pod에 세션이 있으면 직접 전송
+      sendToLocalSession(sessionId, eventName, data, projectId);
+    } else {
+      // Pub/Sub으로 포워딩
+      StompPubSubMessage pubSubMessage =
+          new StompPubSubMessage(sessionId, eventName, data, projectId);
+      forwardToSession(pubSubMessage);
     }
+  }
 
-    // 프로젝트 단위 세션 등록
-    public void registerProjectSession(Long projectId, String sessionId) {
-        String key = PROJECT_SESSION_SET_PREFIX + projectId;
-        redisTemplate.opsForSet().add(key, sessionId);
-        // 세션 만료 관리(옵션): 일정 시간 후 자동 삭제
-        redisTemplate.expire(key, SESSION_TIMEOUT_HOURS, TimeUnit.HOURS);
-        log.info("Registered session {} to project {} set", sessionId, projectId);
-    }
-
-    // 프로젝트 단위 세션 해제
-    public void unregisterProjectSession(Long projectId, String sessionId) {
-        String key = PROJECT_SESSION_SET_PREFIX + projectId;
+  // 모든 프로젝트 Set에서 해당 sessionId를 제거
+  public void removeSessionFromAllProjects(String sessionId) {
+    Set<String> keys = redisTemplate.keys(PROJECT_SESSION_SET_PREFIX + "*");
+    if (keys != null) {
+      for (String key : keys) {
         redisTemplate.opsForSet().remove(key, sessionId);
-        log.info("Unregistered session {} from project {} set", sessionId, projectId);
+      }
     }
-
-    // 프로젝트 단위 세션 Set 조회
-    public Set<String> getProjectSessionIds(Long projectId) {
-        String key = PROJECT_SESSION_SET_PREFIX + projectId;
-        Set<Object> rawSet = redisTemplate.opsForSet().members(key);
-        if (rawSet == null) return Set.of();
-        // Object -> String 변환
-        return rawSet.stream().filter(String.class::isInstance).map(String.class::cast).collect(java.util.stream.Collectors.toSet());
-    }
-
-    // 세션 조회
-    public String getSessionId(Long userId) {
-        String key = ROUTING_KEY_PREFIX + userId;
-        Object value = redisTemplate.opsForValue().get(key);
-        if (value instanceof String) {
-            return (String) value;
-        }
-        return null;
-    }
-
-    // 현재 pod에 세션이 존재하는지 판별
-    public boolean isCurrentSession(String sessionId) {
-        return localSessionMap.containsKey(sessionId);
-    }
-
-    // 특정 sessionId에게 메시지 전송 (stateless 라우팅/포워딩)
-    public void sendMessageToUser(String sessionId, String eventName, Object payload, String projectId) {
-        String data;
-        try {
-            data = objectMapper.writeValueAsString(payload);
-        } catch (JsonProcessingException e) {
-            throw new RuntimeException("Failed to serialize payload", e);
-        }
-        if (isCurrentSession(sessionId)) {
-            // 현재 pod에 세션이 있으면 직접 전송
-            sendToLocalSession(sessionId, eventName, data, projectId);
-        } else {
-            // Pub/Sub으로 포워딩
-            StompPubSubMessage pubSubMessage = new StompPubSubMessage(sessionId, eventName, data, projectId);
-            forwardToSession(pubSubMessage);
-        }
-    }
-
-    // 모든 프로젝트 Set에서 해당 sessionId를 제거
-    public void removeSessionFromAllProjects(String sessionId) {
-        Set<String> keys = redisTemplate.keys(PROJECT_SESSION_SET_PREFIX + "*");
-        if (keys != null) {
-            for (String key : keys) {
-                redisTemplate.opsForSet().remove(key, sessionId);
-            }
-        }
-        log.info("Removed session {} from all project sets", sessionId);
-    }
-} 
+    log.info("Removed session {} from all project sets", sessionId);
+  }
+}

--- a/src/main/java/com/ellu/looper/user/service/S3Service.java
+++ b/src/main/java/com/ellu/looper/user/service/S3Service.java
@@ -39,7 +39,7 @@ public class S3Service {
     metadata.setContentType(file.getContentType());
     metadata.setContentLength(file.getSize());
 
-    amazonS3Client.putObject(bucket, "audio/"+fileName, file.getInputStream(), metadata);
+    amazonS3Client.putObject(bucket, "audio/" + fileName, file.getInputStream(), metadata);
     return generatePresignedUrl(fileName);
   }
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -49,6 +49,9 @@ spring:
 
 server:
   forward-headers-strategy: framework
+  servlet:
+    session:
+      timeout: 60m
 
 cloud:
   aws:
@@ -72,7 +75,7 @@ jwt:
 
 fastapi:
   summary-url: ${FASTAPI_SUMMARY_URL:http://localhost:8000}
-  chatbot-url: ${FASTAPI_CHATBOT_URL:http://localhost:8005}
+  chatbot-url: ${FASTAPI_CHATBOT_URL:http://localhost:8000}
 
 # 현재는 OpenTelemetry가 시스템에 영향을 주지 않도록 완전히 비활성화함
 otel:


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)

* [x] 버그 수정

## 📌 개요

사용자 세션이 일정 시간 비활성 상태가 되면 서버에서 세션을 만료시키게 됩니다. 이 경우 `sessionId`가 유효하지 않거나 null이 되어 SSE(Server-Sent Events) 연결이 끊어지는 문제가 발생했습니다.

이에 대해 아래와 같은 조치를 이미 반영하였습니다:

1. **`application.yml`에 세션 타임아웃 설정 추가**

   * 사용자 세션을 적절한 시간 동안 유지하기 위해 세션 타임아웃을 60분으로 설정하였습니다.

   ```yaml
   server:
     servlet:
       session:
         timeout: 60m
   ```

2. **SSE Keep-Alive(유지) 메커니즘 구현**

   * 브라우저나 프록시가 유휴 연결을 끊는 문제를 방지하기 위해, 서버에서 주기적으로 “ping” 이벤트를 전송하도록 구현하였습니다.
   * 모든 연결된 클라이언트에게 30초 간격으로 무해한 이벤트를 전송하여 세션과 SSE 연결이 유지되도록 처리하였습니다.
 

## ✅ 체크 리스트
- [x] 코드가 정상적으로 컴파일되는지 확인했습니다.
- [x] PR이 관련 이슈를 정확히 참조하고, 적절한 라벨을 선택했습니다.
- [ ] 모든 테스트가 성공적으로 통과했습니다.
- [ ] 관련 문서를 WIKI에 업데이트했습니다.
- [ ] 코드 스타일 가이드라인을 준수했습니다.
- [ ] 코드 리뷰어를 지정했습니다.